### PR TITLE
customize cshift contents from worldspawn

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -415,6 +415,7 @@ void R_NewMap (void)
 	Sky_NewMap (); //johnfitz -- skybox in worldspawn
 	Fog_NewMap (); //johnfitz -- global fog in worldspawn
 	R_ParseWorldspawn (); //ericw -- wateralpha, lavaalpha, telealpha, slimealpha in worldspawn
+	CShift_ParseWorldspawn(); //infin -- cshiftwater, cshiftslime, cshiftlava in worldspawn
 
 	LOC_LoadLocations ();//ProQuake   rook / woods #pqteam
 

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -390,6 +390,67 @@ void V_BonusFlash_f (void)
 
 /*
 =============
+CShift_ParseWorldspawn
+
+called at map load
+=============
+*/
+
+void CShift_ParseWorldspawn(void)
+{
+	char key[128], value[4096];
+	const char* data;
+
+	// reset default cshift values
+	cshift_water = (cshift_t){ {130,80,50}, 128 };
+	cshift_slime = (cshift_t){ {0,25,5}, 150 };
+	cshift_lava = (cshift_t){ {255,80,0}, 150 };
+
+	data = COM_Parse(cl.worldmodel->entities);
+	if (!data)
+		return; // error
+	if (com_token[0] != '{')
+		return; // error
+	while (1)
+	{
+		data = COM_Parse(data);
+		if (!data)
+			return; // error
+		if (com_token[0] == '}')
+			break; // end of worldspawn
+		if (com_token[0] == '_')
+			q_strlcpy(key, com_token + 1, sizeof(key));
+		else
+			q_strlcpy(key, com_token, sizeof(key));
+		while (key[0] && key[strlen(key) - 1] == ' ') // remove trailing spaces
+			key[strlen(key) - 1] = 0;
+		data = COM_Parse(data);
+		if (!data)
+			return; // error
+		q_strlcpy(value, com_token, sizeof(value));
+
+		if (!strcmp("cshiftwater", key))
+		{
+			sscanf(value, "%d %d %d", &cshift_water.destcolor[0], &cshift_water.destcolor[1], &cshift_water.destcolor[2]);
+			cshift_water.percent = 128;
+		}
+
+		if (!strcmp("cshiftslime", key))
+		{
+			sscanf(value, "%d %d %d", &cshift_slime.destcolor[0], &cshift_slime.destcolor[1], &cshift_slime.destcolor[2]);
+			cshift_slime.percent = 150;
+		}
+
+		if (!strcmp("cshiftlava", key))
+		{
+			sscanf(value, "%d %d %d", &cshift_lava.destcolor[0], &cshift_lava.destcolor[1], &cshift_lava.destcolor[2]);
+			cshift_lava.percent = 150;
+		}
+	}
+}
+
+/*
+=============
 V_SetContentsColor
 
 Underwater, lava, etc each has a color shift

--- a/Quake/view.h
+++ b/Quake/view.h
@@ -35,5 +35,7 @@ void V_UpdateBlend (void);
 float V_CalcRoll (vec3_t angles, vec3_t velocity);
 //void V_UpdatePalette (void); //johnfitz
 
+void CShift_ParseWorldspawn(void);
+
 #endif	/* _QUAKE_VIEW_H */
 


### PR DESCRIPTION
* overrides the RGB values of cshift contents from worldspawn keys in the map (`_cshiftwater`, `_cshiftslime`, `_cshiftlava`)