### PR TITLE
Allow multiple definitions in linux link flags

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -11,7 +11,7 @@ MAKEARGS="-j8"
 
 # Make Linux64
 export QSS_CFLAGS="-DQSS_REVISION=`git rev-parse HEAD`"
-export QSS_LDFLAGS=""
+export QSS_LDFLAGS="-Wl,--allow-multiple-definition"
 make clean
 make USE_SDL2=1 $MAKEARGS
 mv quakespasm QSS-M-l64


### PR DESCRIPTION
Recent linux gcc (ubuntu container on chromebook) seems to default this flag to off, as well. Adding flag to linux makefile seems to do the trick.