### PR TITLE
Fix the weapon bob toggle

### DIFF
--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -6249,7 +6249,7 @@ static void M_Game_AdjustSliders(int dir)
 		break;
 
 	case GAME_WEAPONBOB:
-		Cvar_SetValue("cl_bob", !cl_bob.value);
+		Cvar_SetValue("cl_bob", !cl_bob.value * 0.02);
 		break;
 
 	case GAME_DAMAGEKICK:


### PR DESCRIPTION
Makes the weapon bob toggle option set `cl_bob` to `0.02` (The default for `cl_bob`) instead of `1.0`, like it was before