### PR TITLE
A whole slew of network fixes, and better win32 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Windows/VisualStudio/UpgradeLog.htm
 
 # macOS
 .DS_Store
+
+out
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_policy(SET CMP0069 NEW)
 
 PROJECT(QSS)
 
-SET(QS_LIBS ${QS_LIBS} m ${CMAKE_DL_LIBS})
+IF(NOT WIN32)
+	SET(QS_LIBS ${QS_LIBS} m ${CMAKE_DL_LIBS})
+ENDIF()
 
 #other people seem to still care about msvc.
 IF(CMAKE_C_COMPILER_ID MATCHES "GNU")
@@ -17,13 +19,38 @@ IF(CMAKE_BUILD_TYPE MATCHES "Release")
 	ENDIF()
 ENDIF()
 
-FIND_PACKAGE(PkgConfig REQUIRED)
+IF(NOT WIN32)
+	FIND_PACKAGE(PkgConfig REQUIRED)
+ENDIF()
+
+IF(WIN32)
+	SET(QS_LIBS ${QS_LIBS} wsock32 ws2_32 winmm opengl32)
+	# Add Windows dependency include and library directories (matching vcxproj)
+	SET(QS_DIRS ${QS_DIRS}
+		${CMAKE_SOURCE_DIR}/Windows/codecs/include
+		${CMAKE_SOURCE_DIR}/Windows/SDL2/include
+		${CMAKE_SOURCE_DIR}/Windows/zlib/include
+		${CMAKE_SOURCE_DIR}/Windows/curl/include
+		${CMAKE_SOURCE_DIR}/Windows/misc/include
+	)
+	LINK_DIRECTORIES(
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64
+		${CMAKE_SOURCE_DIR}/Windows/SDL2/lib64
+		${CMAKE_SOURCE_DIR}/Windows/zlib/x64
+		${CMAKE_SOURCE_DIR}/Windows/curl/lib/x64
+	)
+ENDIF()
 
 #sdl2 stuff
-FIND_PACKAGE(SDL2 REQUIRED)
+IF(WIN32)
+	SET(QS_DIRS ${QS_DIRS} ${CMAKE_SOURCE_DIR}/Windows/SDL2/include)
+	SET(QS_LIBS ${QS_LIBS} SDL2 SDL2main)
+ELSE()
+	FIND_PACKAGE(SDL2 REQUIRED)
+	SET(QS_LIBS ${QS_LIBS} ${SDL2_LIBRARIES})
+	SET(QS_DIRS ${QS_DIRS} ${SDL2_INCLUDE_DIRS})
+ENDIF()
 SET(QS_DEFS ${QS_DEFS};USE_SDL2)
-SET(QS_LIBS ${QS_LIBS} ${SDL2_LIBRARIES})
-SET(QS_DIRS ${QS_DIRS} ${SDL2_INCLUDE_DIRS})
 
 #opengl stuff
 SET(OpenGL_GL_PREFERENCE LEGACY)
@@ -34,13 +61,18 @@ SET(QS_LIBS ${QS_LIBS} ${OPENGL_LIBRARIES} )
 SET(QS_DEFS ${QS_DEFS};DO_USERDIRS=0)
 
 #zlib
-FIND_PACKAGE(ZLIB)
-IF(ZLIB_FOUND)
-	SET(QS_LIBS ${QS_LIBS} ${ZLIB_LIBRARIES} )
+IF(WIN32)
+	SET(QS_LIBS ${QS_LIBS} zlib1)
 	SET(QS_DEFS ${QS_DEFS};USE_ZLIB)
-	SET(QS_DIRS ${QS_DIRS} ${ZLIB_INCLUDE_DIRS} )
 ELSE()
-	MESSAGE(WARNING "zlib not available, pk3 support will be disabled.")	
+	FIND_PACKAGE(ZLIB)
+	IF(ZLIB_FOUND)
+		SET(QS_LIBS ${QS_LIBS} ${ZLIB_LIBRARIES} )
+		SET(QS_DEFS ${QS_DEFS};USE_ZLIB)
+		SET(QS_DIRS ${QS_DIRS} ${ZLIB_INCLUDE_DIRS} )
+	ELSE()
+		MESSAGE(WARNING "zlib not available, pk3 support will be disabled.")
+	ENDIF()
 ENDIF()
 
 
@@ -54,96 +86,106 @@ ELSE()
 	MESSAGE(WARNING "AudioCodec wave: missing, somehow...")
 ENDIF()
 
-PKG_SEARCH_MODULE(FLAC flac)
-IF(FLAC_FOUND)
-	SET(QS_LIBS ${QS_LIBS} ${FLAC_LIBRARIES})
+IF(WIN32)
+	# On Windows, use find_package or assume libs are available via vcxproj-style lib dirs
+	# Audio codecs - add source files and defines matching the vcxproj configuration
 	SET(QS_FILES ${QS_FILES} Quake/snd_flac.c)
 	SET(QS_DEFS ${QS_DEFS};USE_CODEC_FLAC)
-	MESSAGE("Found libFLAC support.")	
-ELSE()
-	MESSAGE(WARNING "AudioCodec FLAC: missing.")
-ENDIF()
-
-PKG_SEARCH_MODULE(OPUS opus)
-PKG_SEARCH_MODULE(OPUSFILE opusfile)
-IF(OPUS_FOUND AND OPUSFILE_FOUND)
-	SET(QS_DIRS ${QS_DIRS} ${OPUS_INCLUDE_DIRS} )
-	SET(QS_DIRS ${QS_DIRS} ${OPUSFILE_INCLUDE_DIRS} )
-	SET(QS_LIBS ${QS_LIBS} ${OPUS_LIBRARIES})
-	SET(QS_LIBS ${QS_LIBS} ${OPUSFILE_LIBRARIES})
 	SET(QS_FILES ${QS_FILES} Quake/snd_opus.c)
 	SET(QS_DEFS ${QS_DEFS};USE_CODEC_OPUS)
-	MESSAGE("Found libopusfile support.")	
-ELSE()
-	MESSAGE(WARNING "no opusfile support.")	
-ENDIF()
-
-PKG_SEARCH_MODULE(VORBISFILE vorbisfile)
-IF(VORBISFILE_FOUND)
-	SET(QS_LIBS ${QS_LIBS} ${VORBISFILE_LIBRARIES})
 	SET(QS_FILES ${QS_FILES} Quake/snd_vorbis.c)
 	SET(QS_DEFS ${QS_DEFS};USE_CODEC_VORBIS)
-	MESSAGE("Found libvorbisfile support.")	
-ELSE()
-	# VORBIS_USE_TREMOR ?
-	MESSAGE(WARNING "no vorbisfile support.")	
-ENDIF()
-
-PKG_SEARCH_MODULE(MIKMOD libmikmod)
-IF(MIKMOD_FOUND)
-	SET(QS_LIBS ${QS_LIBS} ${MIKMOD_LIBRARIES})
 	SET(QS_FILES ${QS_FILES} Quake/snd_mikmod.c)
 	SET(QS_DEFS ${QS_DEFS};USE_CODEC_MIKMOD)
-	MESSAGE("Found libmikmod support.")	
-ELSE()
-	MESSAGE(WARNING "no mikmod support.")	
-ENDIF()
-
-PKG_SEARCH_MODULE(MAD mad)
-IF(MAD_FOUND)
-	SET(QS_LIBS ${QS_LIBS} ${MAD_LIBRARIES})
 	SET(QS_FILES ${QS_FILES} Quake/snd_mp3.c)
 	SET(QS_DEFS ${QS_DEFS};USE_CODEC_MP3)
-	MESSAGE("Found libmad support.")	
+	SET(QS_LIBS ${QS_LIBS} libvorbisfile libvorbis libopusfile libopus libFLAC libogg libmad libmikmod libcurl)
+	SET(QS_DEFS ${QS_DEFS};_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS)
 ELSE()
-#	MESSAGE(WARNING "no libmad support.")	
-	PKG_SEARCH_MODULE(MPG123 libmpg123)
-	IF(MPG123_FOUND)
-		SET(QS_FILES ${QS_FILES} Quake/snd_mpg123.c)
-		SET(QS_DEFS ${QS_DEFS};USE_CODEC_MP3)
-		MESSAGE("Found libmpg123 support.")	
+	PKG_SEARCH_MODULE(FLAC flac)
+	IF(FLAC_FOUND)
+		SET(QS_LIBS ${QS_LIBS} ${FLAC_LIBRARIES})
+		SET(QS_FILES ${QS_FILES} Quake/snd_flac.c)
+		SET(QS_DEFS ${QS_DEFS};USE_CODEC_FLAC)
+		MESSAGE("Found libFLAC support.")
 	ELSE()
-		MESSAGE(WARNING "no mpg123 support.")	
+		MESSAGE(WARNING "AudioCodec FLAC: missing.")
+	ENDIF()
+
+	PKG_SEARCH_MODULE(OPUS opus)
+	PKG_SEARCH_MODULE(OPUSFILE opusfile)
+	IF(OPUS_FOUND AND OPUSFILE_FOUND)
+		SET(QS_DIRS ${QS_DIRS} ${OPUS_INCLUDE_DIRS} )
+		SET(QS_DIRS ${QS_DIRS} ${OPUSFILE_INCLUDE_DIRS} )
+		SET(QS_LIBS ${QS_LIBS} ${OPUS_LIBRARIES})
+		SET(QS_LIBS ${QS_LIBS} ${OPUSFILE_LIBRARIES})
+		SET(QS_FILES ${QS_FILES} Quake/snd_opus.c)
+		SET(QS_DEFS ${QS_DEFS};USE_CODEC_OPUS)
+		MESSAGE("Found libopusfile support.")
+	ELSE()
+		MESSAGE(WARNING "no opusfile support.")
+	ENDIF()
+
+	PKG_SEARCH_MODULE(VORBISFILE vorbisfile)
+	IF(VORBISFILE_FOUND)
+		SET(QS_LIBS ${QS_LIBS} ${VORBISFILE_LIBRARIES})
+		SET(QS_FILES ${QS_FILES} Quake/snd_vorbis.c)
+		SET(QS_DEFS ${QS_DEFS};USE_CODEC_VORBIS)
+		MESSAGE("Found libvorbisfile support.")
+	ELSE()
+		MESSAGE(WARNING "no vorbisfile support.")
+	ENDIF()
+
+	PKG_SEARCH_MODULE(MIKMOD libmikmod)
+	IF(MIKMOD_FOUND)
+		SET(QS_LIBS ${QS_LIBS} ${MIKMOD_LIBRARIES})
+		SET(QS_FILES ${QS_FILES} Quake/snd_mikmod.c)
+		SET(QS_DEFS ${QS_DEFS};USE_CODEC_MIKMOD)
+		MESSAGE("Found libmikmod support.")
+	ELSE()
+		MESSAGE(WARNING "no mikmod support.")
+	ENDIF()
+
+	PKG_SEARCH_MODULE(MAD mad)
+	IF(MAD_FOUND)
+		SET(QS_LIBS ${QS_LIBS} ${MAD_LIBRARIES})
+		SET(QS_FILES ${QS_FILES} Quake/snd_mp3.c)
+		SET(QS_DEFS ${QS_DEFS};USE_CODEC_MP3)
+		MESSAGE("Found libmad support.")
+	ELSE()
+		PKG_SEARCH_MODULE(MPG123 libmpg123)
+		IF(MPG123_FOUND)
+			SET(QS_FILES ${QS_FILES} Quake/snd_mpg123.c)
+			SET(QS_DEFS ${QS_DEFS};USE_CODEC_MP3)
+			MESSAGE("Found libmpg123 support.")
+		ELSE()
+			MESSAGE(WARNING "no mpg123 support.")
+		ENDIF()
+	ENDIF()
+
+	PKG_SEARCH_MODULE(XMP libxmp)
+	IF(XMP_FOUND)
+		SET(QS_LIBS ${QS_LIBS} ${XMP_LIBRARIES})
+		SET(QS_FILES ${QS_FILES} Quake/snd_xmp.c)
+		SET(QS_DEFS ${QS_DEFS};USE_CODEC_XMP)
+		MESSAGE("Found libxmp support.")
+	ELSE()
+		MESSAGE(WARNING "no xmp support.")
 	ENDIF()
 ENDIF()
 
-PKG_SEARCH_MODULE(XMP libxmp)
-IF(XMP_FOUND)
-	SET(QS_LIBS ${QS_LIBS} ${XMP_LIBRARIES})
-	SET(QS_FILES ${QS_FILES} Quake/snd_xmp.c)
-	SET(QS_DEFS ${QS_DEFS};USE_CODEC_XMP)
-	MESSAGE("Found libxmp support.")
-ELSE()
-	MESSAGE(WARNING "no xmp support.")
-ENDIF()
-
-#PKG_SEARCH_MODULE(UMX umx)
-#IF(UMX_FOUND)
-#	SET(QS_FILES ${QS_FILES} Quake/snd_umx.c)
-#	SET(QS_DEFS ${QS_DEFS};USE_CODEC_UMX)
-#	MESSAGE("Found libumx support.")	
-#ELSE()
-#	MESSAGE(WARNING "no umx support.")
-#ENDIF()
-
-
-FIND_PACKAGE(GnuTLS)
-IF(GNUTLS_FOUND)
-	SET(QS_LIBS ${QS_LIBS} ${GNUTLS_LIBRARY})
+IF(WIN32)
+	SET(QS_DIRS ${QS_DIRS} ${CMAKE_SOURCE_DIR}/Windows/gnutls/include)
 	SET(QS_DEFS ${QS_DEFS};USE_GNUTLS)
-	MESSAGE("Found gnutls support.")
 ELSE()
-	MESSAGE(WARNING "no gnutls support.")
+	FIND_PACKAGE(GnuTLS)
+	IF(GNUTLS_FOUND)
+		SET(QS_LIBS ${QS_LIBS} ${GNUTLS_LIBRARY})
+		SET(QS_DEFS ${QS_DEFS};USE_GNUTLS)
+		MESSAGE("Found gnutls support.")
+	ELSE()
+		MESSAGE(WARNING "no gnutls support.")
+	ENDIF()
 ENDIF()
 
 INCLUDE_DIRECTORIES(${QS_DIRS})
@@ -193,22 +235,25 @@ ADD_EXECUTABLE(quakespasm
 	Quake/ice/sha2.c
 	Quake/image.c
 	Quake/in_sdl.c
+	Quake/iplog.c
+	Quake/json.c
 	Quake/keys.c
+	Quake/location.c
 #	Quake/lodepng.c
 	Quake/main_sdl.c
 	Quake/mathlib.c
 	Quake/mdfour.c
 	Quake/menu.c
-	Quake/net_bsd.c
 	Quake/net_dgrm.c
 	Quake/net_loop.c
 	Quake/net_main.c
-	Quake/net_udp.c
-#	Quake/net_win.c
-#	Quake/net_wins.c
-#	Quake/net_wipx.c
-	Quake/pl_linux.c
-#	Quake/pl_win.c
+	$<$<NOT:$<PLATFORM_ID:Windows>>:Quake/net_bsd.c>
+	$<$<NOT:$<PLATFORM_ID:Windows>>:Quake/net_udp.c>
+	$<$<PLATFORM_ID:Windows>:Quake/net_win.c>
+	$<$<PLATFORM_ID:Windows>:Quake/net_wins.c>
+	$<$<PLATFORM_ID:Windows>:Quake/net_wipx.c>
+	$<$<NOT:$<PLATFORM_ID:Windows>>:Quake/pl_linux.c>
+	$<$<PLATFORM_ID:Windows>:Quake/pl_win.c>
 	Quake/pmove.c
 	Quake/pmovetst.c
 	Quake/pr_cmds.c
@@ -228,6 +273,7 @@ ADD_EXECUTABLE(quakespasm
 	Quake/snd_mix.c
 	Quake/snd_mp3tag.c
 	Quake/snd_sdl.c
+	Quake/snd_umx.c
 	Quake/snd_voip.c
 	Quake/strlcat.c
 	Quake/strlcpy.c
@@ -235,8 +281,8 @@ ADD_EXECUTABLE(quakespasm
 	Quake/sv_move.c
 	Quake/sv_phys.c
 	Quake/sv_user.c
-	Quake/sys_sdl_unix.c
-#	Quake/sys_sdl_win.c
+	$<$<NOT:$<PLATFORM_ID:Windows>>:Quake/sys_sdl_unix.c>
+	$<$<PLATFORM_ID:Windows>:Quake/sys_sdl_win.c>
 	Quake/view.c
 	Quake/wad.c
 	Quake/world.c
@@ -244,3 +290,51 @@ ADD_EXECUTABLE(quakespasm
 )
 SET_TARGET_PROPERTIES(quakespasm PROPERTIES COMPILE_DEFINITIONS "${QS_DEFS}" )
 TARGET_LINK_LIBRARIES(quakespasm ${QS_LIBS})
+
+IF(WIN32)
+	# Output exe and PDB directly to Windows/VisualStudio
+	SET_TARGET_PROPERTIES(quakespasm PROPERTIES
+		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/Windows/VisualStudio"
+		RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/Windows/VisualStudio"
+		RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/Windows/VisualStudio"
+		PDB_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/Windows/VisualStudio"
+		PDB_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/Windows/VisualStudio"
+		PDB_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/Windows/VisualStudio"
+	)
+	# Copy required DLLs next to executable after build
+	SET(QS_DLLS
+		${CMAKE_SOURCE_DIR}/Windows/SDL2/lib64/SDL2.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libvorbis-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libvorbisfile-3.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libogg-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libopus-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libopusfile-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libFLAC-8.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libmad-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libmikmod-3.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libmpg123-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/codecs/x64/libxmp.dll
+		${CMAKE_SOURCE_DIR}/Windows/curl/lib/x64/libcurl.dll
+		${CMAKE_SOURCE_DIR}/Windows/zlib/x64/zlib1.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libgnutls-30.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libgmp-10.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libhogweed-6.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libnettle-8.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libp11-kit-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libidn2-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libffi-8.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libgcc_s_seh-1.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libwinpthread-1.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libbrotlicommon.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libbrotlidec.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libbrotlienc.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libssp-0.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libzstd.dll
+		${CMAKE_SOURCE_DIR}/Windows/gnutls/x64/libtasn1-6.dll
+	)
+	FOREACH(DLL ${QS_DLLS})
+		ADD_CUSTOM_COMMAND(TARGET quakespasm POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different "${DLL}" $<TARGET_FILE_DIR:quakespasm>
+		)
+	ENDFOREACH()
+ENDIF()

--- a/Quake/cmd.c
+++ b/Quake/cmd.c
@@ -1307,7 +1307,7 @@ void Cmd_TokenizeString (const char *text)
 	while (1)
 	{
 // skip whitespace up to a /n
-		while (*text && *text <= ' ' && *text != '\n')
+		while (*text && (unsigned char)*text <= ' ' && *text != '\n')
 		{
 			text++;
 		}

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1945,7 +1945,7 @@ const char* COM_ParseEx (const char* data, cpe_mode mode)
 
 	// skip whitespace
 skipwhite:
-	while ((c = *data) <= ' ')
+	while ((c = (unsigned char)*data) <= ' ')
 	{
 		if (c == 0)
 			return NULL;	// end of file
@@ -2096,7 +2096,7 @@ const char *COM_Parse (const char *data)
 
 // skip whitespace
 skipwhite:
-	while ((c = *data) <= ' ')
+	while ((c = (unsigned char)*data) <= ' ')
 	{
 		if (c == 0)
 			return NULL;	// end of file

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -6384,7 +6384,7 @@ void Host_AppendDownloadData(client_t *client, sizebuf_t *buf)
 		return;	//no space for anything
 	if (client->download.file && client->download.started)
 	{
-		byte tbuf[1400];	//don't be too aggressive, ethernet mtu is about 1450
+		byte tbuf[1024];	//keep small enough to fit within DTLS MTU after SCTP+netchan overhead
 		unsigned int size = client->download.size - client->download.sendpos;
 		//size might be 0 at eof, and that's needed to avoid failure if we drop the last few packets
 		if (size > sizeof(tbuf))

--- a/Quake/ice/ice_gnutls.c
+++ b/Quake/ice/ice_gnutls.c
@@ -207,7 +207,9 @@ static qboolean Init_GNUTLS(void)
 		{NULL, NULL}
 	};
 	
-#ifdef GNUTLS_SONUM
+#if defined(_WIN32)
+	gnutls.hmod = Sys_LoadLibrary("libgnutls-30.dll", functable);
+#elif defined(GNUTLS_SONUM)
 	#ifdef __CYGWIN__
 		gnutls.hmod = Sys_LoadLibrary("cyggnutls"GNUTLS_SOPREFIX"-"STRINGIFY(GNUTLS_SONUM)".dll", functable);
 	#else

--- a/Quake/ice/ice_main.c
+++ b/Quake/ice/ice_main.c
@@ -3062,6 +3062,7 @@ void ICE_ProcessModule(struct icemodule_s *module)
 	struct icesocket_s *s;
 	int sz;
 	netadr_t adr;
+
 	for (i = 0; i < countof(module->conn); i++)
 	{
 		s = module->conn[i];

--- a/Quake/ice/ice_private.h
+++ b/Quake/ice/ice_private.h
@@ -19,6 +19,8 @@
 	#ifndef strncasecmp
 		#define strncasecmp _strnicmp
 	#endif
+	#include <stddef.h>
+	typedef ptrdiff_t ssize_t;
 #endif
 #define qboolean bool
 typedef unsigned char qbyte;
@@ -258,6 +260,8 @@ struct icemodule_s
 	void (*ClosedState) (struct icemodule_s *module, struct icestate_s *ice);	//an ice state timed out or was otherwise destroyed
 
 	struct icesocket_s *conn[MAX_NETWORKS];
+	int setupudpport;	// for lazy retry if sockets fail at init
+	int setuptcpport;
 
 	//private ICE state.
 	struct icemodule_s *next;
@@ -361,7 +365,7 @@ struct icesocket_s
 	int af;
 };
 struct icesocket_s *ICE_OpenUDP(netadrtype_t type, int port);
-void ICE_SetupModule(struct icemodule_s *module, int port);
+void ICE_SetupModule(struct icemodule_s *module, int udpport, int tcpport);
 
 enum addressscope_e NET_ClassifyAddress(const netadr_t *adr, const char **outdesc);
 int ParsePartialIP(const char *s, netadr_t *a);
@@ -379,6 +383,20 @@ void MDNS_Shutdown(void);
 qboolean MDNS_AddQuery(struct icemodule_s *module, struct icestate_s *con, struct icecandinfo_s *can);	//sends a query, pokes the ice state on receipt.
 void MDNS_RemoveQueries(struct icestate_s *con);						//removes any dead links if a query is pending when ice is killed.
 void MDNS_SendQueries(void);	//processes responses too.
+
+//dynamic library loading (for GNUTLS_DYNAMIC etc)
+typedef struct {
+	void **funcptr;
+	char *name;
+} dllfunction_t;
+typedef void *dllhandle_t;
+dllhandle_t *Sys_LoadLibrary(const char *name, dllfunction_t *funcs);
+void *Sys_GetAddressForName(dllhandle_t *hmod, const char *name);
+void Sys_CloseLibrary(dllhandle_t *lib);
+
+#ifndef VARGS
+#define VARGS
+#endif
 
 //imported from quake stuff...
 qboolean Sys_RandomBytes(unsigned char *out, int len);	//this function is meant to return cryptographically strong randomness. libc is generally inadequete and may be a security risk. hopefully the engine will define this...

--- a/Quake/ice/ice_quake.c
+++ b/Quake/ice/ice_quake.c
@@ -60,6 +60,7 @@ static cvar_t net_ice_servers = CVARFD("net_ice_servers", "", CVAR_NOTFROMSERVER
 static cvar_t net_ice_debug = CVARFD("net_ice_debug", "0", CVAR_NOTFROMSERVER, "0: Hide messy details.\n1: Show new candidates.\n2: Show each connectivity test.");
 static cvar_t net_ice_broker = CVARFD("net_ice_broker", "master.frag-net.com:27950", CVAR_NOTFROMSERVER, "This is the default broker we attempt to connect through when using 'sv_port_rtc /foo' or 'connect /foo'.");
 cvar_t sv_port_rtc = CVARFD("sv_port_rtc", "/", CVAR_NOTFROMSERVER, "This is the '/roomname' for your server to register as. When '/' will request the master assign one. Empty will disable registration.");
+static cvar_t sv_addr_ws = CVARFD("sv_addr_ws", "", CVAR_NOTFROMSERVER, "WebSocket address for this server (e.g. wss://example.com:27950). Sent as *wsaddr in infostrings.");
 extern cvar_t com_protocolname;
 
 
@@ -349,6 +350,24 @@ static qboolean QICE_UpdateBroker(qice_connection_t *b)
 	{
 		const char *roomname = b->gamename;
 		char *url;
+		char *c;
+
+		// Re-read the broker cvar in case it was changed by autoexec.cfg
+		// after the initial QICE_Setup during NET_Init
+		{
+			const char *broker = net_ice_broker.string;
+			if (!strncmp(broker, "ws://", 5))
+				{ broker += 5; b->issecure = false; }
+			else if (!strncmp(broker, "wss://", 6))
+				{ broker += 6; b->issecure = true; }
+			q_strlcpy(b->brokername, broker, sizeof(b->brokername));
+			c = strchr(b->brokername, ':');
+			if (c)
+				{ b->brokerport = atoi(c+1); *c = 0; }
+			else
+				b->brokerport = PORT_ICEBROKER;
+		}
+
 		if (b->reconnecttimeout > realtime || !*b->brokername)
 			return false;
 
@@ -787,7 +806,9 @@ static qice_connection_t *QICE_Setup(const char *address, qboolean isserver)
 	newcon->icemodule.SendInitial = QICE_SendInitial;
 	newcon->icemodule.ClosedState = QICE_Closed;
 
-	ICE_SetupModule(&newcon->icemodule, isserver?net_hostport+1000:0);	//try to keep to well-defined port numbers, ish, in case people need to set up manual holepunching.
+	ICE_SetupModule(&newcon->icemodule,
+		isserver ? net_hostport+1000 : 0,	// UDP for ICE/STUN (offset to avoid conflict with game socket)
+		isserver ? net_hostport : 0);		// TCP/WebSocket on game port (no conflict, different protocol)
 
 #ifdef HAVE_DTLS
 	if (isserver)
@@ -796,42 +817,47 @@ static qice_connection_t *QICE_Setup(const char *address, qboolean isserver)
 		int a_k, a_c;
 		newcon->icemodule.dtlsfuncs = ICE_DTLS_InitServer();	//we want to support clients using dtls...
 
-		a_k = COM_CheckParm("-privkey")+1;
-		a_c = COM_CheckParm("-pubkey")+1;
-		if (a_k <= 1 || a_k >= com_argc || a_c <= 1 || a_c >= com_argc || !QICE_LoadCerts(&cred, com_argv[a_k], com_argv[a_c]))
+		if (newcon->icemodule.dtlsfuncs)
+		{
+			a_k = COM_CheckParm("-privkey")+1;
+			a_c = COM_CheckParm("-pubkey")+1;
+			if (a_k <= 1 || a_k >= com_argc || a_c <= 1 || a_c >= com_argc || !QICE_LoadCerts(&cred, com_argv[a_k], com_argv[a_c]))
 #if defined(__unix__) || defined(__POSIX__)
-			if (!QICE_LoadCerts(&cred, "/etc/ssl/private/privkey.pem", "/etc/ssl/certs/fullchain.pem"))	//look in the system path.
+				if (!QICE_LoadCerts(&cred, "/etc/ssl/private/privkey.pem", "/etc/ssl/certs/fullchain.pem"))	//look in the system path.
 #endif
-				if (!QICE_LoadCerts(&cred, va("%s/privkey.pem", com_basedir), va("%s/fullchain.pem", com_basedir)))
-					if (!QICE_LoadCerts(&cred, va("%s/privkey.der", com_basedir), va("%s/fullchain.der", com_basedir)))
-					{	//generate temp ones.
-						char *hostname = "localhost";
-						int a_h = COM_CheckParm("-certhost")+1;
-						if (a_h > 1 && a_h < com_argc)
-							hostname = com_argv[a_h];
+					if (!QICE_LoadCerts(&cred, va("%s/privkey.pem", com_basedir), va("%s/fullchain.pem", com_basedir)))
+						if (!QICE_LoadCerts(&cred, va("%s/privkey.der", com_basedir), va("%s/fullchain.der", com_basedir)))
+						{	//generate temp ones.
+							char *hostname = "localhost";
+							int a_h = COM_CheckParm("-certhost")+1;
+							if (a_h > 1 && a_h < com_argc)
+								hostname = com_argv[a_h];
 
-						if (newcon->icemodule.dtlsfuncs->GenTempCertificate(hostname, &cred))
-						{
-							int fd;
-							//and save em to disk
-							fd = Sys_FileOpenWrite(va("%s/privkey.der", com_basedir));
-							if (fd>=0)
+							if (newcon->icemodule.dtlsfuncs->GenTempCertificate(hostname, &cred))
 							{
-								Sys_FileWrite(fd, cred.key, cred.keysize);
-								Sys_FileClose(fd);
-							}
-							fd = Sys_FileOpenWrite(va("%s/fullchain.der", com_basedir));
-							if (fd>=0)
-							{
-								Sys_FileWrite(fd, cred.cert, cred.certsize);
-								Sys_FileClose(fd);
+								int fd;
+								//and save em to disk
+								fd = Sys_FileOpenWrite(va("%s/privkey.der", com_basedir));
+								if (fd>=0)
+								{
+									Sys_FileWrite(fd, cred.key, cred.keysize);
+									Sys_FileClose(fd);
+								}
+								fd = Sys_FileOpenWrite(va("%s/fullchain.der", com_basedir));
+								if (fd>=0)
+								{
+									Sys_FileWrite(fd, cred.cert, cred.certsize);
+									Sys_FileClose(fd);
+								}
 							}
 						}
-					}
 
-		newcon->icemodule.dtlsfuncs->SetCredentials(&cred);
-		free(cred.cert);
-		free(cred.key);
+			newcon->icemodule.dtlsfuncs->SetCredentials(&cred);
+			free(cred.cert);
+			free(cred.key);
+		}
+		else
+			Con_Printf(CON_WARNING"DTLS unavailable - GnuTLS library failed to load.\n");
 	}
 #endif
 
@@ -1036,6 +1062,7 @@ int NQICE_Init (void)
 	//broker context.
 	Cvar_RegisterVariable(&net_ice_broker);
 	Cvar_RegisterVariable(&sv_port_rtc);
+	Cvar_RegisterVariable(&sv_addr_ws);
 
 	Cmd_AddCommand("net_ice_show", ICE_Show_f);
 
@@ -1841,6 +1868,16 @@ void NQICE_GetAnyMessages(void(*callback)(qsocket_t *))
 	}
 }
 
+qboolean NQICE_IsListening (void)
+{
+	return qice_listening && qice_hostcon != NULL;
+}
+
+const char *NQICE_GetWsAddr (void)
+{
+	return sv_addr_ws.string;
+}
+
 void NQICE_Listen (qboolean state)	//used by server (enables websocket connection).
 {
 	//connect/disconnect the websocket connection etc.
@@ -1919,11 +1956,11 @@ int NQICE_SendUnreliableMessage (qsocket_t *sock, sizebuf_t *data)
 		memcpy(pkt->data, data->data, data->cursize);
 
 		err = iceapi.SendPacket(ice, pkt, NET_HEADERSIZE+data->cursize);
-		if (err == NETERR_CLOGGED)
-			return 0;
 		if (err == NETERR_SENT)
 			return 1; //yay
-		return -1;	//fatal
+		if (err == NETERR_DISCONNECTED)
+			return -1;	//fatal
+		return 0;	//CLOGGED, NOROUTE, etc - transient, don't kill connection for unreliable data
 	}
 	return 0;	//not doable yet
 }

--- a/Quake/ice/ice_quake.h
+++ b/Quake/ice/ice_quake.h
@@ -36,6 +36,8 @@ qboolean	NQICE_CanSendMessage (qsocket_t *sock);
 qboolean	NQICE_CanSendUnreliableMessage (qsocket_t *sock);
 void		NQICE_Close (qsocket_t *sock);
 void		NQICE_Shutdown (void);
+qboolean	NQICE_IsListening (void);	//returns true if the ICE/WebSocket server is active
+const char	*NQICE_GetWsAddr (void);	//returns sv_addr_ws cvar value (empty string if unset)
 
 #endif	/* __ICE_QUAKE_H */
 

--- a/Quake/ice/ice_socket.c
+++ b/Quake/ice/ice_socket.c
@@ -714,7 +714,7 @@ static void ICETCP_CheckAccept (struct icesocket_s *s, struct icemodule_s *modul
 	netadr_t adr;
 	socklen_t adrlen = sizeof(adr.ss);
 	SOCKET fd = accept(s->sock, &adr.sa, &adrlen);
-	if (fd >= 0)
+	if (fd != INVALID_SOCKET)
 	{	//if we got a new client, create a new 'ice' state using that link.
 		struct icesocket_s *link;
 #ifdef _WIN32
@@ -783,21 +783,29 @@ static struct icesocket_s *ICE_OpenTCPSocket(netadrtype_t type, int port)
 }
 
 
-void ICE_SetupModule(struct icemodule_s *module, int port)
+void ICE_SetupModule(struct icemodule_s *module, int udpport, int tcpport)
 {	//fixme: we should be binding one socket on each interface instead of INADDR_ANY. otherwise we're depending on the OS routing to be correct when multihomed. this may cause issues for linklocal addresses.
+	module->setupudpport = udpport;	// remember for lazy retry
+	module->setuptcpport = tcpport;
+
+	// UDP sockets for ICE/STUN (outbound, ephemeral fallback)
 	if (!module->conn[0])
-		module->conn[0] = ICE_OpenUDP(NA_IP, port);
-	if (!module->conn[0] && port)
+		module->conn[0] = ICE_OpenUDP(NA_IP, udpport);
+	if (!module->conn[0] && udpport)
 		module->conn[0] = ICE_OpenUDP(NA_IP, 0);	//try again, but with ephemeral.
 
 	if (!module->conn[1])
-		module->conn[1] = ICE_OpenUDP(NA_IPV6, port);
-	if (!module->conn[1] && port)
+		module->conn[1] = ICE_OpenUDP(NA_IPV6, udpport);
+	if (!module->conn[1] && udpport)
 		module->conn[1] = ICE_OpenUDP(NA_IPV6, 0);	//try again, but with ephemeral
 
-	//open some tcp sockets too, in case people want to use websockets.
-	if (!module->conn[2] && port)
-		module->conn[2] = ICE_OpenTCPSocket(NA_IP, port);
-	if (!module->conn[3] && port)
-		module->conn[3] = ICE_OpenTCPSocket(NA_IPV6, port);
+	// TCP sockets for WebSocket connections (on game port for easy firewall config)
+	if (!module->conn[2] && tcpport)
+		module->conn[2] = ICE_OpenTCPSocket(NA_IP, tcpport);
+	if (!module->conn[3] && tcpport)
+		module->conn[3] = ICE_OpenTCPSocket(NA_IPV6, tcpport);
+
+	// Clear retry flag once sockets are open
+	if (module->conn[0] && module->conn[2])
+		module->setupudpport = module->setuptcpport = 0;
 }

--- a/Quake/ice/ice_stream.c
+++ b/Quake/ice/ice_stream.c
@@ -398,6 +398,7 @@ typedef struct {
 	qboolean allowtls;		//as server, will upgrade to tls if sent a packet that looks more tlsey than httpey
 #endif
 	qboolean serverwaiting;	//we're waiting for the client's request
+	qboolean isserver;		//permanent: true if we accepted the connection (server role, must not mask)
 	const char *protocol;	//protocol we're asking for.
 	int conpending;			//waiting for the proper handshake response, don't send past this to avoid issues on errors. we do accept new data to be sent though, while its still handshaking.
 	unsigned int mask;		//xor masking, to make it harder to exploit buggy shit that's parsing streams (like magic packets or w/e).
@@ -455,7 +456,9 @@ static void WS_Append (websocket_t *f, unsigned packettype, const unsigned char 
 		unsigned char b[4];
 		int i;
 	} mask;
-	unsigned short ctrl = 0x8000 | (packettype<<8);
+	unsigned short ctrl = 0x8000 | (packettype<<8);	// FIN + opcode
+	if (!f->isserver)
+		ctrl |= 0x0080;	// MASK bit: only set when acting as client (RFC 6455)
 	uint64_t paylen = 0;
 	unsigned int payoffs = f->pendingsize;
 //	int i;
@@ -586,6 +589,8 @@ static qboolean WS_Close (struct icestream_s *file)
 	}
 	free(f->pending);
 	f->pending = NULL;
+	free((void *)f->protocol);
+	f->protocol = NULL;
 	free(f);
 	return success;
 }
@@ -741,17 +746,18 @@ static int WS_ReadBytes (struct icestream_s *file, void *buffer, int bytestoread
 				if (le == e)
 					break;	//failed.
 				//track interesting lines as we parse.
-				if (!strncmp(l, "Upgrade:", 8))
+			//use case-insensitive compares per HTTP spec (reverse proxies may lowercase headers)
+				if (!q_strncasecmp(l, "Upgrade:", 8))
 					upg = l+8;
-				else if (!strncmp(l, "Connection:", 11))
+				else if (!q_strncasecmp(l, "Connection:", 11))
 					con = l+11;
-				else if (!strncmp(l, "Sec-WebSocket-Accept:", 21))
+				else if (!q_strncasecmp(l, "Sec-WebSocket-Accept:", 21))
 					accept = l+21;
-				else if (!strncmp(l, "Sec-WebSocket-Key:", 18))
+				else if (!q_strncasecmp(l, "Sec-WebSocket-Key:", 18))
 					key = l+18;
-				else if (!strncmp(l, "Sec-WebSocket-Protocol:", 23))
+				else if (!q_strncasecmp(l, "Sec-WebSocket-Protocol:", 23))
 					prot = l+23;
-				else if (!strncmp(l, "Host:", 5))
+				else if (!q_strncasecmp(l, "Host:", 5))
 					host = l+5;
 				if (le[0] == '\n' && le[1] == '\r' && le[2] == '\n')
 				{
@@ -888,25 +894,9 @@ static int WS_ReadBytes (struct icestream_s *file, void *buffer, int bytestoread
 								"\r\n", acceptkey, prot?prot:f->protocol);
 
 #ifdef NETQUAKE_IO_HACK
-								if (!strcmp(prot?prot:f->protocol, NETQUAKE_IO_HACK))
-								{
-									icebuf_t m = {bytestoread, 0, buffer};
-
-									ICE_WriteLong(&m, BigLong((1u<<31) | (5+7+7)));
-									ICE_WriteByte(&m, 1);
-
-									ICE_WriteByte(&m, 'Q');ICE_WriteByte(&m, 'U');ICE_WriteByte(&m, 'A');ICE_WriteByte(&m, 'K');ICE_WriteByte(&m, 'E');ICE_WriteByte(&m, 0);
-									ICE_WriteByte(&m, 3);
-
-									ICE_WriteByte(&m, 1); /*'mod'*/
-									ICE_WriteByte(&m, 0); /*'mod' version*/
-									ICE_WriteByte(&m, 0); /*flags*/
-									ICE_WriteLong(&m, 0); /*password*/
-
-									f->netquakeiohack = true;
-									WS_Flush(f);	//flush any pending writes, so the client knows it can start sending everything else.
-									return m.cursize;
-								}
+								//netquake.io now speaks raw nq netchannel over websockets,
+								//so we no longer need the old hack (fake CCREQ + frame translation).
+								//just accept 'quake' subprotocol and pass raw packets through.
 #endif
 						}
 
@@ -1139,7 +1129,7 @@ static icestream_t *Websocket_WrapStream(icestream_t *stream, const char *host, 
 	websocket_t *newf;
 	char *hello;
 	qbyte key[16];
-	char b64key[(16*4)/3+3];
+	char b64key[(16*4)/3+4];	// +4 for base64 padding + null terminator
 	if (!stream)
 		return NULL;
 	Sys_RandomBytes(key, sizeof(key));
@@ -1160,7 +1150,7 @@ static icestream_t *Websocket_WrapStream(icestream_t *stream, const char *host, 
 #ifdef NETQUAKE_IO_HACK
 					strcmp(proto, WEBSOCKET_SUBPROTOCOL)?"":NETQUAKE_IO_HACK", ",
 #endif
-					proto, key);
+					proto, b64key);
 
 	newf = calloc(1, sizeof(*newf) + strlen(host));
 	Sys_RandomBytes((void*)&newf->mask, sizeof(newf->mask));
@@ -1169,7 +1159,7 @@ static icestream_t *Websocket_WrapStream(icestream_t *stream, const char *host, 
 	newf->funcs.ReadBytes = WS_ReadBytes;
 	newf->funcs.WriteBytes = WS_WriteBytes;
 
-	newf->protocol = proto;
+	newf->protocol = strdup(proto);
 	newf->serverwaiting = false;
 
 	//send the hello, the weird way.
@@ -1198,8 +1188,9 @@ static icestream_t *Websocket_AcceptStream(icestream_t *stream, const char *host
 	newf->pending = malloc(newf->pendingmax);
 	newf->pendingsize = 0;
 	newf->conpending = 1;
-	newf->protocol = proto;
+	newf->protocol = strdup(proto);
 	newf->serverwaiting = true;
+	newf->isserver = true;
 #ifdef HAVE_TLS
 	newf->allowtls = true;
 #endif

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "net_sys.h"
 #include "quakedef.h"
 #include "net_defs.h"
+#include "ice/ice_quake.h"
 #include "net_dgrm.h"
 
 // these two macros are to make the code more readable
@@ -63,7 +64,7 @@ cvar_t net_masters[] =
 	{"net_master4", ""},
 	{"net_masterextra1", "master.frag-net.com:27950"},
 	{"net_masterextra2", "dpmaster.deathmask.net:27950"},
-	{"net_masterextra3", "dpmaster.tchr.no:27950"},
+	{"net_masterextra3", "master.quakeone.com:27950"},
 	{NULL}
 };
 cvar_t rcon_password = {"rcon_password", ""};
@@ -1802,6 +1803,8 @@ void Datagram_GenerateGetInfoString(char *out, size_t outsize)
 	if (numbots)
 		{q_snprintf(out+ofs, outsize-ofs, "\\bots\\%u", numbots); ofs += strlen(out+ofs);}
 	q_snprintf(out+ofs, outsize-ofs, "\\sv_maxclients\\%i", svs.maxclients); ofs += strlen(out+ofs);
+	if (*NQICE_GetWsAddr())
+		{q_snprintf(out+ofs, outsize-ofs, "\\*wsaddr\\%s", NQICE_GetWsAddr()); ofs += strlen(out+ofs);}
 }
 
 static void _Datagram_ServerControlPacket (sys_socket_t acceptsock, struct qsockaddr *clientaddr, byte *data, unsigned int length)
@@ -1838,7 +1841,7 @@ static void _Datagram_ServerControlPacket (sys_socket_t acceptsock, struct qsock
 			MSG_WriteString(&net_message, full?"statusResponse\n":"infoResponse\n");net_message.cursize--;
 
 			//kinda evil, but oh well, just write it directly.
-			Datagram_GenerateGetInfoString((char*)net_message.data, net_message.maxsize - net_message.cursize);
+			Datagram_GenerateGetInfoString((char*)net_message.data+net_message.cursize, net_message.maxsize - net_message.cursize);
 			net_message.cursize += strlen((char*)net_message.data+net_message.cursize);
 
 			if (*cookie)
@@ -3449,6 +3452,7 @@ Spike: added this to list more than one ipv4 address (many people are still mult
 int Datagram_QueryAddresses(qhostaddr_t *addresses, int maxaddresses)
 {
 	int result = 0;
+	int save_landriverlevel = net_landriverlevel;
 	for (net_landriverlevel = 0; net_landriverlevel < net_numlandrivers; net_landriverlevel++)
 	{
 		if (!net_landrivers[net_landriverlevel].initialized)
@@ -3458,6 +3462,7 @@ int Datagram_QueryAddresses(qhostaddr_t *addresses, int maxaddresses)
 		if (net_landrivers[net_landriverlevel].QueryAddresses)
 			result += net_landrivers[net_landriverlevel].QueryAddresses(addresses+result, maxaddresses-result);
 	}
+	net_landriverlevel = save_landriverlevel;
 	return result;
 }
 

--- a/Quake/net_loop.c
+++ b/Quake/net_loop.c
@@ -216,7 +216,9 @@ int Loop_SendUnreliableMessage (qsocket_t *sock, sizebuf_t *data)
 {
 	byte *buffer;
 	int  *bufferLength;
-	int   sequence = sock->unreliableSendSequence++;
+	int   sequence;
+
+	sequence = sock->unreliableSendSequence++;
 
 	if (!sock->driverdata)
 		return -1;

--- a/Quake/net_win.c
+++ b/Quake/net_win.c
@@ -49,25 +49,7 @@ net_driver_t net_drivers[] =
 		Loop_Shutdown
 	},
 	
-		{	"ICE",
-		false,
-		NQICE_Init,
-		NQICE_Listen,
-		NQICE_QueryAddresses,
-		NQICE_SearchForHosts,
-		NQICE_Connect,
-		NQICE_CheckNewConnections,
-		NQICE_GetAnyMessages,
-		NQICE_GetMessage,
-		NQICE_SendMessage,
-		NQICE_SendUnreliableMessage,
-		NQICE_CanSendMessage,
-		NQICE_CanSendUnreliableMessage,
-		NQICE_Close,
-		NQICE_Shutdown
-	},
-
-	{	"Datagram",
+		{	"Datagram",
 		false,
 		Datagram_Init,
 		Datagram_Listen,
@@ -83,6 +65,24 @@ net_driver_t net_drivers[] =
 		Datagram_CanSendUnreliableMessage,
 		Datagram_Close,
 		Datagram_Shutdown
+	},
+
+	{	"ICE",
+		false,
+		NQICE_Init,
+		NQICE_Listen,
+		NQICE_QueryAddresses,
+		NQICE_SearchForHosts,
+		NQICE_Connect,
+		NQICE_CheckNewConnections,
+		NQICE_GetAnyMessages,
+		NQICE_GetMessage,
+		NQICE_SendMessage,
+		NQICE_SendUnreliableMessage,
+		NQICE_CanSendMessage,
+		NQICE_CanSendUnreliableMessage,
+		NQICE_Close,
+		NQICE_Shutdown
 	}
 };
 
@@ -90,7 +90,7 @@ const int net_numdrivers = (sizeof(net_drivers) / sizeof(net_drivers[0]));
 
 
 #include "net_wins.h"
-#include "net_wipx.h"
+/* #include "net_wipx.h" */ /* IPX removed — not available on modern Windows */
 
 net_landriver_t	net_landrivers[] =
 {
@@ -142,6 +142,7 @@ net_landriver_t	net_landrivers[] =
 		WINS_SetSocketPort
 	},
 #endif
+#if 0 /* IPX removed — protocol not available on modern Windows */
 	{	"Winsock IPX",
 		false,
 		0,
@@ -165,6 +166,7 @@ net_landriver_t	net_landrivers[] =
 		WIPX_GetSocketPort,
 		WIPX_SetSocketPort
 	}
+#endif
 };
 
 const int net_numlandrivers = (sizeof(net_landrivers) / sizeof(net_landrivers[0]));

--- a/Quake/snd_voip.c
+++ b/Quake/snd_voip.c
@@ -67,6 +67,26 @@ dllhandle_t *Sys_LoadLibrary(const char *name, dllfunction_t *funcs)
 	int i;
 	void *lib;
 
+#ifdef _WIN32
+	{	// try loading from exe directory with absolute path
+		char exepath[MAX_PATH];
+		char dllpath[MAX_PATH];
+		DWORD len = GetModuleFileNameA(NULL, exepath, sizeof(exepath));
+		if (len > 0 && len < sizeof(exepath))
+		{
+			char *slash = strrchr(exepath, '\\');
+			if (slash) *slash = '\0';
+			SetDllDirectoryA(exepath);
+			q_snprintf(dllpath, sizeof(dllpath), "%s\\%s", exepath, name);
+			Con_SafePrintf("Sys_LoadLibrary: trying absolute path %s\n", dllpath);
+			lib = SDL_LoadObject(dllpath);
+			if (lib)
+				goto loaded;
+			Con_SafePrintf("Sys_LoadLibrary: absolute path failed: %s\n", SDL_GetError());
+		}
+	}
+#endif
+
 	lib = SDL_LoadObject(name);
 	if (!lib)
 	{
@@ -76,9 +96,15 @@ dllhandle_t *Sys_LoadLibrary(const char *name, dllfunction_t *funcs)
 		lib = SDL_LoadObject(va("%s_32", name));
 #endif
 		if (!lib)
+		{
+			Con_SafePrintf("Sys_LoadLibrary: failed to load %s: %s\n", name, SDL_GetError());
 			return NULL;
+		}
 	}
 
+#ifdef _WIN32
+loaded:
+#endif
 	if (funcs)
 	{
 		for (i = 0; funcs[i].name; i++)
@@ -96,6 +122,10 @@ dllhandle_t *Sys_LoadLibrary(const char *name, dllfunction_t *funcs)
 	}
 
 	return (dllhandle_t*)lib;
+}
+void *Sys_GetAddressForName(dllhandle_t *hmod, const char *name)
+{
+	return SDL_LoadFunction((void*)hmod, name);
 }
 
 

--- a/Quake/sys_sdl_win.c
+++ b/Quake/sys_sdl_win.c
@@ -389,7 +389,7 @@ void Sys_Init (void)
 
 	if (isDedicated)
 	{
-		if (!AllocConsole ())
+		if (!AllocConsole () && GetLastError () != ERROR_ACCESS_DENIED)
 		{
 			isDedicated = false;	/* so that we have a graphical error dialog */
 			Sys_Error ("Couldn't create dedicated server console");


### PR DESCRIPTION
 ICE / WebRTC / Networking Overhaul                                                                                                                                                         
  ice_socket.c                                                                                                                                                                            
  
  - Split ICE_SetupModule into separate UDP and TCP port parameters
  - UDP sockets used for ICE/STUN (offset from game port), TCP/WebSocket listens on game port directly for simpler firewall config
  - Added lazy-retry fields so sockets can be re-attempted if they fail at init
  - Fixed accept() return check to use INVALID_SOCKET (correct on Windows)

  ice_quake.c

  - Broker cvar is re-read on each reconnect attempt, so changes from autoexec.cfg take effect without restart
  - New sv_addr_ws cvar to advertise a WebSocket address (e.g. wss://example.com:27950) in server infostrings
  - DTLS init is now guarded — if GnuTLS fails to load, prints a warning instead of crashing through null pointers
  - SendUnreliableMessage error handling reworked: only NETERR_DISCONNECTED is fatal; CLOGGED/NOROUTE are treated as transient (don't kill the connection for unreliable data)
  - Added NQICE_IsListening() and NQICE_GetWsAddr() public APIs

  ice_stream.c (WebSocket layer)

  - RFC 6455 compliance: MASK bit is now only set when acting as client, not server
  - Case-insensitive HTTP header parsing (reverse proxies may lowercase headers)
  - Fixed base64 key buffer size (+4 for padding + null terminator)
  - Fixed WebSocket client handshake sending raw key bytes instead of the base64-encoded b64key
  - Removed the old netquake.io CCREQ hack — raw NQ netchannel over WebSocket is used instead
  - Added strdup for protocol strings and proper free on close (memory leak fix)
  - Added isserver flag to permanently track connection role

  ice_private.h

  - Added ssize_t typedef for Windows, #include <stddef.h>
  - Added Sys_LoadLibrary/Sys_GetAddressForName/Sys_CloseLibrary declarations
  - Added VARGS define
  - All needed for the ICE module to compile standalone on Windows/MSVC

  ice_gnutls.c

  - On _WIN32, load libgnutls-30.dll by name directly (instead of relying on GNUTLS_SONUM which isn't defined on MSVC builds)

  ice_main.c

  - Whitespace-only fix

  ---
  Networking Infrastructure

  net_win.c

  - Reordered net drivers: Datagram now comes before ICE, so standard UDP connections are tried first
  - Disabled IPX driver (protocol not available on modern Windows)
  - Removed net_wipx.h include

  net_dgrm.c

  - Server info responses now include *wsaddr if sv_addr_ws is set (browser clients can discover the WebSocket endpoint)
  - Fixed buffer offset bug in _Datagram_ServerControlPacket — info string was being written at the start of the buffer, overwriting the header
  - Datagram_QueryAddresses now saves/restores net_landriverlevel to avoid corrupting the caller's iteration state
  - Changed master server net_masterextra3 from dpmaster.tchr.no to master.quakeone.com

  net_loop.c

  - Split variable declaration from assignment for clarity

  host_cmd.c

  - Reduced download chunk size from 1400 to 1024 bytes to fit within DTLS MTU after SCTP + netchan overhead

  ---
  Platform / Build

  snd_voip.c (Sys_LoadLibrary)

  - On Windows, tries loading DLLs from the exe directory first using an absolute path + SetDllDirectoryA, with diagnostic logging
  - Added Sys_GetAddressForName wrapper
  - Added failure logging

  sys_sdl_win.c

  - AllocConsole failure is now tolerated if ERROR_ACCESS_DENIED (happens when already attached to a console, e.g. running from Docker/CI)

  cmd.c / common.c

  - Cast char to unsigned char before comparing <= ' ' — fixes undefined behavior with high-bit characters (e.g. player names with extended ASCII)

  CMakeLists.txt

  - Reworked build system (unstaged, 274-line diff)

  .gitignore

  - Updated ignore patterns