### PR TITLE
Add Ice over UDP/DTLS support

### DIFF
--- a/Quake/ice/ice_private.h
+++ b/Quake/ice/ice_private.h
@@ -365,6 +365,7 @@ struct icesocket_s
 	int af;
 };
 struct icesocket_s *ICE_OpenUDP(netadrtype_t type, int port);
+struct icesocket_s *ICE_WrapExistingSocket(SOCKET sock, int af);
 void ICE_SetupModule(struct icemodule_s *module, int udpport, int tcpport);
 
 enum addressscope_e NET_ClassifyAddress(const netadr_t *adr, const char **outdesc);

--- a/Quake/ice/ice_quake.c
+++ b/Quake/ice/ice_quake.c
@@ -703,6 +703,9 @@ static qboolean QICE_LoadCerts(struct dtlslocalcred_s *cred, char *priv, char *c
 }
 #endif
 
+static struct icesocket_s *shared_game_socket4;	//datagram driver's shared IPv4 UDP socket
+static struct icesocket_s *shared_game_socket6;	//datagram driver's shared IPv6 UDP socket
+
 static qice_connection_t *QICE_Setup(const char *address, qboolean isserver)
 {	//[rtc://][broker[:port]]/[roomname]
 	qice_connection_t *newcon;
@@ -806,9 +809,30 @@ static qice_connection_t *QICE_Setup(const char *address, qboolean isserver)
 	newcon->icemodule.SendInitial = QICE_SendInitial;
 	newcon->icemodule.ClosedState = QICE_Closed;
 
-	ICE_SetupModule(&newcon->icemodule,
-		isserver ? net_hostport+1000 : 0,	// UDP for ICE/STUN (offset to avoid conflict with game socket)
-		isserver ? net_hostport : 0);		// TCP/WebSocket on game port (no conflict, different protocol)
+	if (isserver && (shared_game_socket4 || shared_game_socket6))
+	{	//use the shared game sockets — each module gets its own wrapper (freed by CloseModule)
+		if (shared_game_socket4)
+		{
+			struct icesocket_s *wrap = ICE_WrapExistingSocket(shared_game_socket4->sock, shared_game_socket4->af);
+			if (wrap)
+				newcon->icemodule.conn[0] = wrap;
+		}
+		if (shared_game_socket6)
+		{
+			struct icesocket_s *wrap = ICE_WrapExistingSocket(shared_game_socket6->sock, shared_game_socket6->af);
+			if (wrap)
+				newcon->icemodule.conn[1] = wrap;
+		}
+		ICE_SetupModule(&newcon->icemodule,
+			0,						// shared sockets handle UDP; 0 = don't open another
+			net_hostport);			// TCP/WebSocket on game port
+	}
+	else
+	{
+		ICE_SetupModule(&newcon->icemodule,
+			0,						// ephemeral if needed (client), or none (no shared socket)
+			isserver ? net_hostport : 0);		// TCP/WebSocket on game port
+	}
 
 #ifdef HAVE_DTLS
 	if (isserver)
@@ -870,151 +894,406 @@ static qice_connection_t *QICE_Setup(const char *address, qboolean isserver)
 static qboolean qice_listening;	//whether we want to host or not.
 static qice_connection_t *qice_hostcon;	//broker for our server side.
 
+//---- Broker DTLS listener ----
+//Accepts DTLS connections from brokers on the game UDP port.
+//Decrypted packets are processed as connectionless with dtls_authenticated=true.
+#ifdef HAVE_DTLS
+#define MAX_BROKER_DTLS_PEERS 8
+#define BROKER_DTLS_TIMEOUT 60.0
+struct broker_dtls_peer_s
+{
+	netadr_t addr;
+	void *dtlsstate;
+	const dtlsfuncs_t *funcs;
+	double timeout;
+	struct icesocket_s *sendsock;	//for sending encrypted data back
+};
+static struct broker_dtls_peer_s broker_dtls_peers[MAX_BROKER_DTLS_PEERS];
+static qboolean broker_dtls_authenticated;	//set when processing a decrypted packet
+static struct broker_dtls_peer_s *broker_dtls_active;	//the peer being processed (for encrypted responses)
 
-#if 0//def HAVE_SERVER
-void SVC_ICE_Offer(netadr_t *from)
+static neterr_t BrokerDTLS_Push(void *cbctx, const qbyte *data, size_t length)
+{	//send raw DTLS data back to the broker
+	struct broker_dtls_peer_s *peer = (struct broker_dtls_peer_s *)cbctx;
+	if (!peer->sendsock)
+		return NETERR_NOROUTE;
+	return peer->sendsock->SendPacket(peer->sendsock, &peer->addr, data, length);
+}
+
+static void BrokerDTLS_Established(void **cbctx, void *state)
+{	//cookie verified, allocate permanent peer state
+	struct broker_dtls_peer_s *temp = (struct broker_dtls_peer_s *)*cbctx;
+	struct broker_dtls_peer_s *peer = NULL;
+	int i, oldest = 0;
+
+	//find a free slot or reuse oldest
+	for (i = 0; i < MAX_BROKER_DTLS_PEERS; i++)
+	{
+		if (!broker_dtls_peers[i].dtlsstate)
+		{
+			peer = &broker_dtls_peers[i];
+			break;
+		}
+		if (broker_dtls_peers[i].timeout < broker_dtls_peers[oldest].timeout)
+			oldest = i;
+	}
+	if (!peer)
+	{	//reuse oldest
+		peer = &broker_dtls_peers[oldest];
+		if (peer->dtlsstate && peer->funcs)
+			peer->funcs->DestroyContext(peer->dtlsstate);
+		memset(peer, 0, sizeof(*peer));
+	}
+
+	peer->addr = temp->addr;
+	peer->funcs = temp->funcs;
+	peer->sendsock = temp->sendsock;
+	peer->dtlsstate = state;
+	peer->timeout = Sys_DoubleTime() + BROKER_DTLS_TIMEOUT;
+
+	*cbctx = peer;	//update so gnutls uses the permanent peer
+	Con_DPrintf("BrokerDTLS: established session with %s\n",
+		NET_BaseAdrToString((char[64]){0}, 64, &peer->addr));
+}
+
+//returns true if packet was consumed (either by an established session or a handshake)
+qboolean BrokerDTLS_HandlePacket(byte *data, int len, struct qsockaddr *qaddr, struct icesocket_s *sendsock)
+{
+	netadr_t from;
+	struct broker_dtls_peer_s *peer = NULL;
+	const dtlsfuncs_t *funcs;
+	int i;
+	byte decrypted[2048 + 1];	//+1 for null terminator written by _Datagram_ServerControlPacket
+	size_t decrypted_len = 0;
+	neterr_t err;
+
+	//convert address
+	{	struct sockaddr_storage ss;
+		memset(&ss, 0, sizeof(ss));
+		memcpy(&ss, qaddr, sizeof(*qaddr));
+		SockadrToNetadr(&ss, sizeof(ss), &from);
+	}
+
+	//find existing session
+	for (i = 0; i < MAX_BROKER_DTLS_PEERS; i++)
+	{
+		if (broker_dtls_peers[i].dtlsstate && NET_CompareAdr(&broker_dtls_peers[i].addr, &from))
+		{
+			peer = &broker_dtls_peers[i];
+			break;
+		}
+	}
+
+	if (peer)
+	{	//established session — decrypt
+		peer->timeout = Sys_DoubleTime() + BROKER_DTLS_TIMEOUT;
+
+		//drive timeouts (retransmits etc)
+		if (peer->funcs->Timeouts)
+			peer->funcs->Timeouts(peer->dtlsstate);
+
+		err = peer->funcs->Received(peer->dtlsstate, &from, data, len, decrypted, sizeof(decrypted), &decrypted_len);
+		if (err == NETERR_DISCONNECTED)
+		{	//stale session — destroy and try a fresh handshake
+			Con_DPrintf("BrokerDTLS: stale session, rehandshaking\n");
+			peer->funcs->DestroyContext(peer->dtlsstate);
+			memset(peer, 0, sizeof(*peer));
+			peer = NULL;
+		}
+		else
+		{
+			if (err == NETERR_SENT && decrypted_len > 0)
+			{	//got decrypted data — process as connectionless
+				broker_dtls_authenticated = true;
+				broker_dtls_active = peer;
+				if (decrypted_len >= 4 && decrypted[0] == 0xFF && decrypted[1] == 0xFF && decrypted[2] == 0xFF && decrypted[3] == 0xFF)
+				{
+					extern void _Datagram_BrokerPacket(byte *data, unsigned int length, sys_socket_t sock, struct qsockaddr *addr);
+					_Datagram_BrokerPacket(decrypted, (unsigned int)decrypted_len, sendsock->sock, qaddr);
+				}
+				broker_dtls_active = NULL;
+				broker_dtls_authenticated = false;
+			}
+			return true;	//consumed (even if handshake/keepalive with no app data)
+		}
+	}
+
+	//no existing session (or stale one just destroyed) — try to start a handshake
+	funcs = ICE_DTLS_InitServer();
+	if (!funcs || !funcs->CheckConnection)
+		return false;
+
+	{	struct broker_dtls_peer_s temp;
+		memset(&temp, 0, sizeof(temp));
+		temp.addr = from;
+		temp.funcs = funcs;
+		temp.sendsock = sendsock;
+		return funcs->CheckConnection(&temp, &from, sizeof(from), data, len, BrokerDTLS_Push, BrokerDTLS_Established);
+	}
+}
+
+void BrokerDTLS_Cleanup(void)
+{
+	int i;
+	double now = Sys_DoubleTime();
+	for (i = 0; i < MAX_BROKER_DTLS_PEERS; i++)
+	{
+		if (broker_dtls_peers[i].dtlsstate)
+		{
+			if (broker_dtls_peers[i].funcs->Timeouts)
+				broker_dtls_peers[i].funcs->Timeouts(broker_dtls_peers[i].dtlsstate);
+			if (broker_dtls_peers[i].timeout < now)
+			{
+				Con_DPrintf("BrokerDTLS: session timeout\n");
+				broker_dtls_peers[i].funcs->DestroyContext(broker_dtls_peers[i].dtlsstate);
+				memset(&broker_dtls_peers[i], 0, sizeof(broker_dtls_peers[i]));
+			}
+		}
+	}
+}
+
+void BrokerDTLS_Shutdown(void)
+{
+	int i;
+	for (i = 0; i < MAX_BROKER_DTLS_PEERS; i++)
+	{
+		if (broker_dtls_peers[i].dtlsstate)
+		{
+			broker_dtls_peers[i].funcs->DestroyContext(broker_dtls_peers[i].dtlsstate);
+			memset(&broker_dtls_peers[i], 0, sizeof(broker_dtls_peers[i]));
+		}
+	}
+}
+
+qboolean BrokerDTLS_IsAuthenticated(void)
+{
+	return broker_dtls_authenticated;
+}
+
+//send data through the active broker DTLS session (encrypts before sending)
+int BrokerDTLS_Send(const void *data, int len)
+{
+	if (!broker_dtls_active || !broker_dtls_active->dtlsstate)
+		return -1;
+	return (broker_dtls_active->funcs->Transmit(broker_dtls_active->dtlsstate, (const qbyte *)data, len) == NETERR_SENT) ? 0 : -1;
+}
+#else //!HAVE_DTLS — stubs
+qboolean BrokerDTLS_HandlePacket(byte *data, int len, struct qsockaddr *addr, struct icesocket_s *sendsock) { return false; }
+void BrokerDTLS_Cleanup(void) {}
+void BrokerDTLS_Shutdown(void) {}
+qboolean BrokerDTLS_IsAuthenticated(void) { return false; }
+int BrokerDTLS_Send(const void *data, int len) { return -1; }
+#endif //HAVE_DTLS
+
+#ifdef SUPPORT_ICE
+//Adapted for QSS-M: handles ice_offer/ice_ccand connectionless packets from a broker on the game UDP port.
+//The broker sends these so browsers can establish WebRTC DataChannels directly to the server.
+
+static void Z_StrCat(char **dest, const char *src)
+{	//append src to a Z_Malloc'd string, reallocating as needed
+	size_t oldlen = *dest ? strlen(*dest) : 0;
+	size_t addlen = strlen(src);
+	char *n = (char *)Z_Malloc(oldlen + addlen + 1);
+	if (*dest)
+	{
+		memcpy(n, *dest, oldlen);
+		Z_Free(*dest);
+	}
+	memcpy(n + oldlen, src, addlen + 1);
+	*dest = n;
+}
+
+//per-peer candidate trickle state (keyed by broker id), since icestate_s.u is not available
+#define MAX_ICE_PEERS 16
+static struct
+{
+	char brokerid[64];
+	char *text;
+	unsigned int inseq;
+	unsigned int outseq;
+	double timeout;
+} ice_peer_state[MAX_ICE_PEERS];
+
+static int ICE_FindOrAllocPeer(const char *brokerid, qboolean alloc)
+{
+	int i, oldest = 0;
+	for (i = 0; i < MAX_ICE_PEERS; i++)
+	{
+		if (!strcmp(ice_peer_state[i].brokerid, brokerid))
+			return i;
+		if (ice_peer_state[i].timeout < ice_peer_state[oldest].timeout)
+			oldest = i;
+	}
+	if (!alloc)
+		return -1;
+	//reuse oldest slot
+	i = oldest;
+	if (ice_peer_state[i].text)
+		Z_Free(ice_peer_state[i].text);
+	memset(&ice_peer_state[i], 0, sizeof(ice_peer_state[i]));
+	q_strlcpy(ice_peer_state[i].brokerid, brokerid, sizeof(ice_peer_state[i].brokerid));
+	ice_peer_state[i].timeout = Sys_DoubleTime() + 30;
+	return i;
+}
+
+void SVC_ICE_Offer(const char *clientaddr, const char *brokerid, const char *sdpdata, const char *brokeraddr, ice_udp_send_t sendpacket)
 {	//handles an 'ice_offer' udp message from a broker
-//	extern cvar_t net_ice_servers;
 	struct icestate_s *ice;
-	static float throttletimer;
 	const char *sdp, *s;
 	char buf[1400];
-	int sz;
-	const char *clientaddr = Cmd_Argv(1);	//so we can do ip bans on the client's srflx address
-	const char *brokerid = Cmd_Argv(2);	//specific id to identify the pairing on the broker.
-	netadr_t adr;
+	int sz, pi;
 #ifdef HAVE_JSON
 	json_t *json;
 #endif
+	Con_DPrintf("ICE: ice_offer from %s broker_id=%s dtls=%i\n", clientaddr, brokerid, BrokerDTLS_IsAuthenticated());
+#ifdef HAVE_DTLS
+	if (!BrokerDTLS_IsAuthenticated())
+	{
+		Con_DPrintf("ICE: ice_offer rejected - not DTLS authenticated\n");
+		return;
+	}
+#endif
 	if (!qice_hostcon)
-		return;	//err..?
-	if (from->prot != NP_DTLS && from->prot != NP_TLS)
-	{	//a) dtls provides a challenge (ensuring we can at least ban them).
-		//b) this contains the caller's ips. We'll be pinging them anyway, but hey. also it'll be too late at this point but it keeps the other side honest.
-		Con_DPrintf(CON_WARNING"%s: ice handshake from %s was unencrypted\n", NET_AdrToString (buf, sizeof(buf), from), clientaddr);
+	{
+		Con_DPrintf("ICE: no host connection (sv_port_rtc not set?)\n");
 		return;
 	}
 
-	/*if (!NET_StringToAdr_NoDNS(clientaddr, 0, &adr))	//no dns-resolution denial-of-service attacks please.
-	{
-		Con_DPrintf(CON_WARNING"%s: ice handshake specifies bad client address: %s\n", NET_AdrToString (buf, sizeof(buf), from), clientaddr);
+	pi = ICE_FindOrAllocPeer(brokerid, true);
+	if (pi < 0)
 		return;
-	}
-	if (SV_BannedReason(&adr)!=NULL)
-	{
-		Con_DPrintf(CON_WARNING"%s: ice handshake for %s - banned\n", NET_AdrToString (buf, sizeof(buf), from), clientaddr);
-		return;
-	}*/
+	ice_peer_state[pi].timeout = Sys_DoubleTime() + 30;
 
 	ice = iceapi.Create(&qice_hostcon->icemodule, brokerid, clientaddr, ICEF_DEFAULT, ICEP_SERVER);
 	if (!ice)
-		return;	//some kind of error?!?
-	//use the sender as a stun server. FIXME: put server's address in the request instead.
-	iceapi.Set(ice, "server", va("stun:%s", NET_AdrToString (buf, sizeof(buf), from)));	//the sender should be able to act as a stun server for use. should probably just pass who its sending to and call it a srflx anyway, tbh.
+	{
+		Con_Printf("ICE: iceapi.Create failed for broker_id=%s\n", brokerid);
+		return;
+	}
+
+	//use the broker as a STUN server to discover our server-reflexive address
+	if (brokeraddr && *brokeraddr)
+		iceapi.Set(ice, "server", va("stun:%s", brokeraddr));
 
 	s = net_ice_servers.string;
 	while((s=COM_Parse(s)))
 		iceapi.Set(ice, "server", com_token);
 
-	sdp = MSG_ReadString();
+	sdp = sdpdata;
 #ifdef HAVE_JSON
-	json = JSON_Parse(sdp);	//browsers are poo
+	json = JSON_Parse(sdp);
 	if (json)
-		sdp = JSON_GetString(json, "sdp", buf,sizeof(buf), "");
+		sdp = JSON_GetString(json, "sdp", buf, sizeof(buf), "");
 #endif
-
 	if (iceapi.Set(ice, "sdpoffer", sdp))
 	{
-		iceapi.Set(ice, "state", STRINGIFY(ICE_CONNECTING));	//skip gathering, just trickle.
+		iceapi.Set(ice, "state", STRINGIFY(ICE_CONNECTING));
 
-		q_snprintf(buf, sizeof(buf), "\xff\xff\xff\xff""ice_answer %s", brokerid);
-		sz = strlen(buf)+1;
+		q_snprintf(buf, sizeof(buf), "\xff\xff\xff\xff""ice_answer %s\n", brokerid);
+		sz = strlen(buf);
 		if (iceapi.Get(ice, "sdpanswer", buf+sz, sizeof(buf)-sz))
 		{
 			sz += strlen(buf+sz);
-
-			NET_SendPacket(svs.sockets, sz, buf, from);
+			sendpacket(buf, sz);
 		}
+		else
+			Con_DPrintf("ICE: sdpanswer generation failed for broker_id=%s\n", brokerid);
 	}
+	else
+		Con_DPrintf("ICE: sdpoffer parse failed for broker_id=%s\n", brokerid);
 #ifdef HAVE_JSON
 	JSON_Destroy(json);
 #endif
-
-	//and because we won't have access to its broker, disconnect it from any persistent state to let it time out.
-	iceapi.Close(ice, false);
 }
-void SVC_ICE_Candidate(netadr_t *from)
+
+void SVC_ICE_Candidate(const char *brokerid, const char *seq_s, const char *ack_s, const char *canddata, ice_udp_send_t sendpacket)
 {	//handles an 'ice_ccand' udp message from a broker
 	struct icestate_s *ice;
 #ifdef HAVE_JSON
 	json_t *json;
 #endif
-	const char *sdp;
+	const char *sdp, *line;
 	char buf[1400];
-	const char *brokerid = Cmd_Argv(1);	//specific id to identify the pairing on the broker.
-	unsigned int seq = atoi(Cmd_Argv(2));	//their seq, to ack and prevent dupes
-	unsigned int ack = atoi(Cmd_Argv(3));	//so we don't resend endlessly... *cough*
+	int pi;
+	unsigned int seq = atoi(seq_s);
+	unsigned int ack = atoi(ack_s);
+	Con_DPrintf("ICE: ice_ccand broker_id=%s seq=%u ack=%u\n", brokerid, seq, ack);
+#ifdef HAVE_DTLS
+	if (!BrokerDTLS_IsAuthenticated())
+		return;
+#endif
 	if (!qice_hostcon)
 		return;
-	if (from->prot != NP_DTLS && from->prot != NP_WSS && from->prot != NP_TLS)
+
+	ice = iceapi.Find(&qice_hostcon->icemodule, brokerid);
+	if (!ice)
 	{
+		Con_DPrintf("ICE: ice_ccand - no ICE state for broker_id=%s\n", brokerid);
 		return;
 	}
-	ice = iceapi.Find(NULL, brokerid);
-	if (!ice)
-		return;	//bad state. lost packet?
 
-	//parse the inbound candidates
-	for(;;)
+	pi = ICE_FindOrAllocPeer(brokerid, false);
+	if (pi < 0)
+		return;
+	ice_peer_state[pi].timeout = Sys_DoubleTime() + 30;
+
+	//parse the inbound candidates (newline-separated in canddata)
+	line = canddata;
+	while (line && *line)
 	{
-		sdp = MSG_ReadStringLine();
-		if (msg_badread || !*sdp)
-			break;
-		if (seq++ < ice->u.inseq)
-			continue;
-		ice->u.inseq++;
-#ifdef HAVE_JSON
-		json = JSON_Parse(sdp);
-		if (json)
+		const char *nl = strchr(line, '\n');
+		size_t len = nl ? (size_t)(nl - line) : strlen(line);
+		char linebuf[512];
+		if (len >= sizeof(linebuf)) len = sizeof(linebuf)-1;
+		memcpy(linebuf, line, len);
+		linebuf[len] = 0;
+
+		if (seq++ >= ice_peer_state[pi].inseq && *linebuf)
 		{
-			sdp = buf;
-			buf[0]='a';
-			buf[1]='=';
-			buf[2]=0;
-			JSON_GetString(json, "candidate", buf+2,sizeof(buf)-2, NULL);
-		}
-#endif
-		iceapi.Set(ice, "sdp", sdp);
+			ice_peer_state[pi].inseq++;
+			sdp = linebuf;
 #ifdef HAVE_JSON
-		JSON_Destroy(json);
+			json = JSON_Parse(sdp);
+			if (json)
+			{
+				sdp = buf;
+				buf[0]='a'; buf[1]='='; buf[2]=0;
+				JSON_GetString(json, "candidate", buf+2, sizeof(buf)-2, NULL);
+			}
 #endif
+			iceapi.Set(ice, "sdp", sdp);
+#ifdef HAVE_JSON
+			JSON_Destroy(json);
+#endif
+		}
+		line = nl ? nl+1 : NULL;
 	}
 
-	while (ack > ice->u.outseq)
-	{	//drop an outgoing candidate line
-		char *nl = strchr(ice->u.text, '\n');
+	while (ack > ice_peer_state[pi].outseq)
+	{
+		char *nl = ice_peer_state[pi].text ? strchr(ice_peer_state[pi].text, '\n') : NULL;
 		if (nl)
 		{
 			nl++;
-			memmove(ice->u.text, nl, strlen(nl)+1);	//chop it away.
-			ice->u.outseq++;
+			memmove(ice_peer_state[pi].text, nl, strlen(nl)+1);
+			ice_peer_state[pi].outseq++;
 			continue;
 		}
-		//wut?
-		if (ack > ice->u.outseq)
-			ice->u.outseq = ack;	//a gap? oh noes!
+		if (ack > ice_peer_state[pi].outseq)
+			ice_peer_state[pi].outseq = ack;
 		break;
 	}
 
-	//check for new candidates to include
 	while (iceapi.GetLCandidateSDP(ice, buf, sizeof(buf)))
 	{
-		Z_StrCat(&ice->u.text, buf);
-		Z_StrCat(&ice->u.text, "\n");
+		Z_StrCat(&ice_peer_state[pi].text, buf);
+		Z_StrCat(&ice_peer_state[pi].text, "\n");
 	}
 
-	q_snprintf(buf, sizeof(buf), "\xff\xff\xff\xff""ice_scand %s %u %u\n%s", brokerid, ice->u.outseq, ice->u.inseq, ice->u.text?ice->u.text:"");
-	NET_SendPacket(svs.sockets, strlen(buf), buf, from);
+	q_snprintf(buf, sizeof(buf), "\xff\xff\xff\xff""ice_scand %s %u %u\n%s",
+		brokerid, ice_peer_state[pi].outseq, ice_peer_state[pi].inseq,
+		ice_peer_state[pi].text ? ice_peer_state[pi].text : "");
+	sendpacket(buf, strlen(buf));
 }
 #endif
 
@@ -1578,6 +1857,10 @@ qsocket_t *NQICE_CheckNewConnections (void)
 {	//poll the server's websocket.
 	qice_connection_t *b = qice_hostcon;	//stoopid globals.
 
+#ifdef HAVE_DTLS
+	BrokerDTLS_Cleanup();	//expire old sessions
+#endif
+
 	if (b)
 		QICE_UpdateBroker(b);
 	return NULL;
@@ -1878,6 +2161,152 @@ const char *NQICE_GetWsAddr (void)
 	return sv_addr_ws.string;
 }
 
+static char nqice_fp_cache[128];	//cached base64 fingerprint, computed once
+
+const char *NQICE_GetFingerprint (void)
+{
+#ifdef HAVE_DTLS
+	struct dtlslocalcred_s cred = {NULL,0,NULL,0};
+	qbyte digest[DIGEST_MAXSIZE];
+	const dtlsfuncs_t *funcs;
+
+	if (*nqice_fp_cache)
+		return nqice_fp_cache;
+
+	//load the same cert that QICE_Setup uses for the broker DTLS
+	if (!QICE_LoadCerts(&cred, va("%s/privkey.pem", com_basedir), va("%s/fullchain.pem", com_basedir)))
+		if (!QICE_LoadCerts(&cred, va("%s/privkey.der", com_basedir), va("%s/fullchain.der", com_basedir)))
+		{
+			//no cert files yet — generate and save so QICE_Setup finds them later
+			funcs = ICE_DTLS_InitServer();
+			if (!funcs || !funcs->GenTempCertificate)
+				return "";
+			if (!funcs->GenTempCertificate("localhost", &cred))
+				return "";
+			{
+				int fd;
+				fd = Sys_FileOpenWrite(va("%s/privkey.der", com_basedir));
+				if (fd >= 0) { Sys_FileWrite(fd, cred.key, cred.keysize); Sys_FileClose(fd); }
+				fd = Sys_FileOpenWrite(va("%s/fullchain.der", com_basedir));
+				if (fd >= 0) { Sys_FileWrite(fd, cred.cert, cred.certsize); Sys_FileClose(fd); }
+			}
+		}
+
+	if (!cred.certsize)
+		return "";
+
+	CalcHash(&hash_certfp, digest, sizeof(digest), cred.cert, cred.certsize);
+	Base64_EncodeBlock(digest, hash_certfp.digestsize, nqice_fp_cache, sizeof(nqice_fp_cache));
+	free(cred.cert);
+	free(cred.key);
+	return nqice_fp_cache;
+#else
+	return "";
+#endif
+}
+
+
+void NQICE_UnshareGameSockets (void)
+{	//invalidate shared sockets — call before closing the datagram listening sockets
+	if (shared_game_socket4)
+	{
+		free(shared_game_socket4);
+		shared_game_socket4 = NULL;
+	}
+	if (shared_game_socket6)
+	{
+		free(shared_game_socket6);
+		shared_game_socket6 = NULL;
+	}
+}
+
+void NQICE_ShareGameSocket (sys_socket_t sock)
+{	//share the datagram driver's UDP socket with ICE instead of ICE opening its own
+	struct sockaddr_storage sa;
+	socklen_t salen = sizeof(sa);
+	struct icesocket_s *wrap, **slot;
+	int af;
+
+	if (getsockname((SOCKET)sock, (struct sockaddr *)&sa, &salen) < 0)
+		return;
+	af = sa.ss_family;
+	slot = (af == AF_INET6) ? &shared_game_socket6 : &shared_game_socket4;
+
+	if (*slot)
+	{
+		if ((*slot)->sock == (SOCKET)sock)
+			return;	//same socket, nothing to do
+		free(*slot);
+		*slot = NULL;
+	}
+	wrap = ICE_WrapExistingSocket(sock, af);
+	if (wrap)
+		*slot = wrap;
+}
+
+qboolean NQICE_ProcessPacket (byte *data, int len, struct qsockaddr *addr, void(*callback)(qsocket_t *))
+{	//forward a non-quake UDP packet to the ICE module for STUN/DTLS/SCTP processing
+	netadr_t from;
+	struct icesocket_s *via;
+	extern int net_driverlevel;
+	int saved_driverlevel = net_driverlevel;
+	void(*saved_servercb)(qsocket_t *) = qice_servercb;
+	int i;
+
+	//convert qsockaddr to netadr_t
+	memset(&from, 0, sizeof(from));
+	{	struct sockaddr_storage ss;
+		memset(&ss, 0, sizeof(ss));
+		memcpy(&ss, addr, sizeof(*addr));
+		SockadrToNetadr(&ss, sizeof(ss), &from);
+	}
+
+	//pick the shared socket matching the original qsockaddr family
+	via = (addr->qsa_family == AF_INET6) ? shared_game_socket6 : shared_game_socket4;
+	if (!via)
+		via = shared_game_socket4 ? shared_game_socket4 : shared_game_socket6;
+	if (!via)
+		return false;
+
+	//set net_driverlevel to the ICE driver so NET_NewQSocket sets the correct driver
+	for (i = 0; i < net_numdrivers; i++)
+	{
+		if (net_drivers[i].QGetAnyMessages == NQICE_GetAnyMessages)
+		{
+			net_driverlevel = i;
+			break;
+		}
+	}
+
+	//set the server callback so game packets get delivered during ProcessPacket
+	qice_servercb = callback;
+
+	//try ICE first (handles STUN connectivity checks and WebRTC DTLS)
+	if (qice_hostcon && iceapi.ProcessPacket(&qice_hostcon->icemodule, via, &from, data, len))
+	{
+		qice_servercb = saved_servercb;
+		net_driverlevel = saved_driverlevel;
+		return true;
+	}
+
+#ifdef HAVE_DTLS
+	//DTLS range (byte 20-63): try broker DTLS if ICE didn't claim it
+	if (len > 0 && data[0] >= 20 && data[0] < 64)
+	{
+		if (BrokerDTLS_HandlePacket(data, len, addr, via))
+		{
+			qice_servercb = saved_servercb;
+			net_driverlevel = saved_driverlevel;
+			return true;
+		}
+	}
+#endif
+
+	qice_servercb = saved_servercb;
+	net_driverlevel = saved_driverlevel;
+	return false;
+}
+
 void NQICE_Listen (qboolean state)	//used by server (enables websocket connection).
 {
 	//connect/disconnect the websocket connection etc.
@@ -2077,6 +2506,32 @@ void NQICE_Shutdown (void)
 {
 	int i;
 	NQICE_Listen(false);	//just in case.
+
+	nqice_fp_cache[0] = 0;	//clear cached fingerprint
+
+#ifdef HAVE_DTLS
+	BrokerDTLS_Shutdown();
+#endif
+
+	if (shared_game_socket4)
+	{
+		free(shared_game_socket4);
+		shared_game_socket4 = NULL;
+	}
+	if (shared_game_socket6)
+	{
+		free(shared_game_socket6);
+		shared_game_socket6 = NULL;
+	}
+
+	for (i = 0; i < MAX_ICE_PEERS; i++)
+	{
+		if (ice_peer_state[i].text)
+		{
+			Z_Free(ice_peer_state[i].text);
+			ice_peer_state[i].text = NULL;
+		}
+	}
 
 	qice_msgqueuesize = 0;
 	for (i = 0; i < countof(qice_msgqueue); i++)

--- a/Quake/ice/ice_quake.h
+++ b/Quake/ice/ice_quake.h
@@ -38,6 +38,20 @@ void		NQICE_Close (qsocket_t *sock);
 void		NQICE_Shutdown (void);
 qboolean	NQICE_IsListening (void);	//returns true if the ICE/WebSocket server is active
 const char	*NQICE_GetWsAddr (void);	//returns sv_addr_ws cvar value (empty string if unset)
+const char	*NQICE_GetFingerprint (void);	//returns base64 DTLS cert fingerprint for *fp infostring
+void		NQICE_ShareGameSocket (sys_socket_t sock);	//share the datagram driver's UDP socket with ICE
+void		NQICE_UnshareGameSockets (void);	//invalidate shared sockets (call before closing datagram sockets)
+qboolean	NQICE_ProcessPacket (byte *data, int len, struct qsockaddr *addr, void(*callback)(qsocket_t *));	//forward a non-quake packet to ICE. returns true if consumed.
+qboolean	BrokerDTLS_HandlePacket (byte *data, int len, struct qsockaddr *addr, struct icesocket_s *sendsock);
+void		BrokerDTLS_Cleanup (void);
+void		BrokerDTLS_Shutdown (void);
+qboolean	BrokerDTLS_IsAuthenticated (void);
+int		BrokerDTLS_Send (const void *data, int len);	//returns 0 on success
+
+//broker-to-server ICE signaling over the UDP game port (for /udp/IP:Port connections)
+typedef void (*ice_udp_send_t)(const void *data, int len);
+void		SVC_ICE_Offer(const char *clientaddr, const char *brokerid, const char *sdpdata, const char *brokeraddr, ice_udp_send_t sendpacket);
+void		SVC_ICE_Candidate(const char *brokerid, const char *seq_s, const char *ack_s, const char *canddata, ice_udp_send_t sendpacket);
 
 #endif	/* __ICE_QUAKE_H */
 

--- a/Quake/ice/ice_socket.c
+++ b/Quake/ice/ice_socket.c
@@ -783,6 +783,24 @@ static struct icesocket_s *ICE_OpenTCPSocket(netadrtype_t type, int port)
 }
 
 
+static void ICEUDP_NoClose(struct icesocket_s *s)
+{	//do NOT close the socket — we don't own it
+	free(s);
+}
+struct icesocket_s *ICE_WrapExistingSocket(SOCKET sock, int af)
+{	//wrap an existing socket for ICE use without taking ownership
+	struct icesocket_s *n = calloc(1, sizeof(*n));
+	if (!n)
+		return NULL;
+	n->SendPacket = ICEUDP_SendPacket;
+	n->RecvPacket = ICEUDP_RecvPacket;
+	n->EnumerateAddresses = ICEUDP_GetAddresses;
+	n->CloseSocket = ICEUDP_NoClose;	//don't close — datagram driver owns it
+	n->af = af;
+	n->sock = sock;
+	return n;
+}
+
 void ICE_SetupModule(struct icemodule_s *module, int udpport, int tcpport)
 {	//fixme: we should be binding one socket on each interface instead of INADDR_ANY. otherwise we're depending on the OS routing to be correct when multihomed. this may cause issues for linklocal addresses.
 	module->setupudpport = udpport;	// remember for lazy retry

--- a/Quake/ice/ice_stream.c
+++ b/Quake/ice/ice_stream.c
@@ -457,11 +457,11 @@ static void WS_Append (websocket_t *f, unsigned packettype, const unsigned char 
 		int i;
 	} mask;
 	unsigned short ctrl = 0x8000 | (packettype<<8);	// FIN + opcode
-	if (!f->isserver)
-		ctrl |= 0x0080;	// MASK bit: only set when acting as client (RFC 6455)
 	uint64_t paylen = 0;
 	unsigned int payoffs = f->pendingsize;
 //	int i;
+	if (!f->isserver)
+		ctrl |= 0x0080;	// MASK bit: only set when acting as client (RFC 6455)
 	if (!f->stream)
 		return;	//can't do anything anyway...
 	switch((ctrl>>8) & 0xf)

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -997,6 +997,7 @@ void Datagram_GetAnyMessages(void(*callback)(qsocket_t *))
 
 			if (length < 4)
 				continue;
+
 			if (BigLong(packetBuffer.length) & NETFLAG_CTL)
 			{
 				_Datagram_ServerControlPacket(sock, &addr, (byte *)&packetBuffer, length);
@@ -1028,7 +1029,12 @@ void Datagram_GetAnyMessages(void(*callback)(qsocket_t *))
 					}
 				}
 			}
-			//stray packet... ignore it and just try the next
+			if (!s)
+			{	//unmatched packet — try broker DTLS, then ICE (STUN/DTLS/SCTP)
+				byte leadbyte = ((byte *)&packetBuffer)[0];
+				if (leadbyte < 4 || (leadbyte >= 20 && leadbyte < 64))
+					NQICE_ProcessPacket((byte *)&packetBuffer, length, &addr, callback);
+			}
 		}
 	}
 	for (s = net_activeSockets; s; s = s->next)
@@ -1709,13 +1715,18 @@ void Datagram_Listen (qboolean state)
 		heartbeatctx = NULL;
 	}
 
+	NQICE_UnshareGameSockets();	//invalidate before sockets change
+
 	for (i = 0; i < net_numlandrivers; i++)
 	{
 		if (net_landrivers[i].initialized)
 		{
 			net_landrivers[i].listeningSock = net_landrivers[i].Listen (state);
 			if (net_landrivers[i].listeningSock != INVALID_SOCKET)
+			{
 				islistening = true;
+				NQICE_ShareGameSocket(net_landrivers[i].listeningSock);
+			}
 
 			for (s = net_activeSockets; s; s = s->next)
 			{
@@ -1805,6 +1816,27 @@ void Datagram_GenerateGetInfoString(char *out, size_t outsize)
 	q_snprintf(out+ofs, outsize-ofs, "\\sv_maxclients\\%i", svs.maxclients); ofs += strlen(out+ofs);
 	if (*NQICE_GetWsAddr())
 		{q_snprintf(out+ofs, outsize-ofs, "\\*wsaddr\\%s", NQICE_GetWsAddr()); ofs += strlen(out+ofs);}
+	if (*NQICE_GetFingerprint())
+		{q_snprintf(out+ofs, outsize-ofs, "\\*fp\\%s", NQICE_GetFingerprint()); ofs += strlen(out+ofs);}
+}
+
+//send context for ICE UDP signaling callback — set before calling SVC_ICE_Offer/Candidate
+static sys_socket_t _ice_send_sock;
+static struct qsockaddr *_ice_send_addr;
+static void _Datagram_ICE_SendPacket(const void *data, int len)
+{
+	if (BrokerDTLS_IsAuthenticated())
+	{	//response goes back encrypted through the DTLS session
+		BrokerDTLS_Send(data, len);
+		return;
+	}
+	dfunc.Write(_ice_send_sock, (byte *)data, len, _ice_send_addr);
+}
+
+//called by BrokerDTLS to process decrypted connectionless packets
+void _Datagram_BrokerPacket(byte *data, unsigned int length, sys_socket_t sock, struct qsockaddr *addr)
+{
+	_Datagram_ServerControlPacket(sock, addr, data, length);
 }
 
 static void _Datagram_ServerControlPacket (sys_socket_t acceptsock, struct qsockaddr *clientaddr, byte *data, unsigned int length)
@@ -1859,7 +1891,7 @@ static void _Datagram_ServerControlPacket (sys_socket_t acceptsock, struct qsock
 						total /= NUM_PING_TIMES;
 						total *= 1000;	//put it in ms
 
-						MSG_WriteString(&net_message, va("\n%i %i %i_%i \"%s\"", 
+						MSG_WriteString(&net_message, va("\n%i %i %i_%i \"%s\"",
 							svs.clients[i].old_frags, (int)total, svs.clients[i].colors&15, svs.clients[i].colors>>4, svs.clients[i].name
 						));net_message.cursize--;
 					}
@@ -1868,6 +1900,48 @@ static void _Datagram_ServerControlPacket (sys_socket_t acceptsock, struct qsock
 
 			dfunc.Write (acceptsock, net_message.data, net_message.cursize, clientaddr);
 			SZ_Clear(&net_message);
+		}
+		else if (!strcmp(Cmd_Argv(0), "ice_offer") || !strcmp(Cmd_Argv(0), "ice_ccand"))
+		{	//broker-to-server ICE signaling for /udp/IP:Port browser connections
+			//broker format: "command <args>\n<payload>" — separated by \n, not \0
+			//parse manually because Cmd_TokenizeString mangles some token values
+			const char *line = (const char *)data+4;
+			const char *nl = strchr(line, '\n');
+			const char *payload = (nl && nl < (const char *)data + length) ? nl + 1 : "";
+			char header[256];
+			char *args[8];
+			int nargs = 0;
+			char *p;
+
+			//copy header line for safe tokenization
+			{	size_t hlen = nl ? (size_t)(nl - line) : strlen(line);
+				if (hlen >= sizeof(header)) hlen = sizeof(header)-1;
+				memcpy(header, line, hlen);
+				header[hlen] = 0;
+			}
+
+			//split header by spaces
+			p = header;
+			while (*p && nargs < 8)
+			{
+				while (*p == ' ') p++;
+				if (!*p) break;
+				args[nargs++] = p;
+				while (*p && *p != ' ') p++;
+				if (*p) *p++ = 0;
+			}
+
+			if (nargs >= 1)
+			{
+				//capture send context for the callback
+				_ice_send_sock = acceptsock;
+				_ice_send_addr = clientaddr;
+
+				if (!strcmp(args[0], "ice_offer") && nargs >= 3)
+					SVC_ICE_Offer(args[1], args[2], payload, dfunc.AddrToString(clientaddr, false), _Datagram_ICE_SendPacket);
+				else if (!strcmp(args[0], "ice_ccand") && nargs >= 4)
+					SVC_ICE_Candidate(args[1], args[2], args[3], payload, _Datagram_ICE_SendPacket);
+			}
 		}
 		return;
 	}


### PR DESCRIPTION
"Add Ice over UDP/DTLS support" - inspired from FTE's implementation

  This PR enables browser clients to connect to the game server via WebRTC, with ICE signaling happening over the game's existing UDP port (encrypted with DTLS), rather than requiring a separate WebSocket connection to the broker. This is a big deal since this can work over a single UDP game port without any fancy networking. 

  ---
  Broker DTLS Subsystem (ice_quake.c)

  New BrokerDTLS_* module that accepts DTLS sessions from brokers directly on the game UDP port:

  - BrokerDTLS_HandlePacket — Receives raw UDP, looks up or initiates a DTLS session, decrypts, and dispatches the plaintext as connectionless packets. Handles stale        
  sessions by destroying and rehandshaking.
  - BrokerDTLS_Established — Callback when DTLS handshake completes; allocates a permanent peer slot (pool of 8, LRU eviction).
  - BrokerDTLS_Push — Sends encrypted DTLS data back through the shared game socket.
  - BrokerDTLS_Send — Encrypts and sends application data through the active session (used for ICE signaling responses).
  - BrokerDTLS_Cleanup — Expires timed-out sessions (60s timeout). Called from NQICE_CheckNewConnections.
  - BrokerDTLS_Shutdown — Destroys all sessions on engine shutdown.
  - No-op stubs provided when HAVE_DTLS is not defined.

  ICE Signaling Over UDP (ice_quake.c)

  Rewrote SVC_ICE_Offer and SVC_ICE_Candidate (previously dead code behind #if 0):

  - Decoupled from FTE's netadr_t protocol field — No longer checks from->prot; instead uses BrokerDTLS_IsAuthenticated() to verify the packet came through an encrypted     
  channel.
  - Decoupled from MSG_ReadString/Cmd_Argv — Takes explicit parameters (clientaddr, brokerid, sdpdata, brokeraddr, sendpacket callback), so it can be called from either the 
  WebSocket broker path or the new UDP/DTLS path.
  - Per-peer candidate trickle state — New ice_peer_state[16] array keyed by broker ID, replacing icestate_s.u fields which aren't available in QSS's ICE implementation.    
  Tracks inseq/outseq for reliable candidate delivery.
  - Z_StrCat helper for building candidate text strings.
  - ICE_FindOrAllocPeer — LRU slot allocator for peer state.
  - NQICE_GetFingerprint — Returns base64-encoded SHA-256 fingerprint of the DTLS certificate, advertised in server info as *fp.

  Shared Game Socket Architecture (ice_quake.c, ice_socket.c)

  Instead of ICE opening its own UDP sockets (which conflicted with the game port), the datagram driver's sockets are now shared:

  - NQICE_ShareGameSocket — Called from Datagram_Listen when sockets are opened; wraps them for ICE use.
  - NQICE_UnshareGameSockets — Invalidates wrappers before sockets are closed.
  - ICE_WrapExistingSocket (ice_socket.c) — Creates an icesocket_s wrapper around an existing socket FD with a no-op close function (the datagram driver owns the socket).   
  - QICE_Setup — When shared sockets exist, wraps them into the ICE module's conn[] slots instead of calling ICE_SetupModule with a port.

  Packet Routing (ice_quake.c, net_dgrm.c)

  - NQICE_ProcessPacket — Entry point called from the datagram driver for unmatched packets. Converts qsockaddr to netadr_t, sets the correct net_driverlevel for ICE, then  
  tries iceapi.ProcessPacket (STUN/WebRTC DTLS) followed by BrokerDTLS_HandlePacket (broker DTLS, byte range 20-63).
  - Datagram_GetAnyMessages — Stray packets (not matching any active connection) are now forwarded to NQICE_ProcessPacket if the lead byte matches STUN (0-3) or DTLS (20-63)
   ranges per RFC 7983 multiplexing.
  - _Datagram_BrokerPacket — Bridge function called by BrokerDTLS_HandlePacket to feed decrypted connectionless packets back into _Datagram_ServerControlPacket.
  - _Datagram_ICE_SendPacket — Send callback that routes responses through DTLS encryption if authenticated, or raw UDP otherwise.

  Server Info (net_dgrm.c)

  - *fp infostring key — Server advertises its DTLS certificate fingerprint so the broker can verify the connection.

  ICE Signaling Dispatch (net_dgrm.c)

  - _Datagram_ServerControlPacket — New handler for ice_offer and ice_ccand connectionless packets. Manually tokenizes the header (space-separated) and extracts the
  newline-separated payload, because Cmd_TokenizeString would mangle the SDP data.

  Minor (ice_stream.c, ice_private.h)

  - ice_stream.c — Increased decrypted buffer by +1 for null terminator safety.
  - ice_private.h — Added ICE_WrapExistingSocket declaration.