### PR TITLE
Dtls session handling

### DIFF
--- a/Quake/ice/ice_main.c
+++ b/Quake/ice/ice_main.c
@@ -2802,7 +2802,10 @@ void ICE_Tick(void)
 				continue;
 			}
 			else if ((signed int)(curtime-con->icetimeout) > 0)
-				ICE_SetFailed(con, S_COLOR_GRAY"[%s]: ice timeout\n", con->friendlyname);
+			{
+				Con_DPrintf(S_COLOR_GRAY"[%s]: brokerless ice timeout\n", con->friendlyname);
+				con->state = ICE_FAILED;	//will be destroyed on next tick
+			}
 		}
 
 		if (!(con->modeflags & ICEF_ALLOW_PROBE))
@@ -3019,10 +3022,10 @@ static struct icestate_s *ICE_DirectConnectedInternal(struct icemodule_s *module
 		con->server[0].con = link;
 		con->chosenpeer.connum = con->server[0].connum = 1+MAX_NETWORKS+countof(con->server)+0;	//send through our private socket instead of wrapping in TURN.
 		con->server[0].addr = con->chosenpeer;
-		Con_Printf("%s: WebSocket connection\n", peer);
+		Con_DPrintf("%s: WebSocket connection\n", peer);
 	}
 	else
-		Con_Printf("%s: Direct connection\n", peer);
+		Con_DPrintf("%s: Direct connection\n", peer);
 
 	con->brokerless = true;
 	con->state = ICE_CONNECTED;

--- a/Quake/ice/ice_main.c
+++ b/Quake/ice/ice_main.c
@@ -1897,6 +1897,10 @@ static qboolean ICE_Set(struct icestate_s *con, const char *prop, const char *va
 		free(con->rpwd);
 		con->rpwd = strdup(value);
 	}
+	else if (!strcmp(prop, "brokerless"))
+	{
+		con->brokerless = atoi(value) != 0;
+	}
 	else if (!strcmp(prop, "server"))
 	{
 		netadr_t hostadr[1];
@@ -2791,7 +2795,7 @@ void ICE_Tick(void)
 	{
 		if (con->brokerless)
 		{
-			if (con->state <= ICE_GATHERING)
+			if (con->state <= ICE_GATHERING || con->state == ICE_FAILED)
 			{
 				*link = con->next;
 				ICE_Destroy(con);
@@ -3253,7 +3257,9 @@ static qboolean ICE_ProcessPacket (struct icemodule_s *module, struct icesocket_
 								con->lc = src;
 								src->peer = adr;
 								NET_BaseAdrToString(src->info.addr, sizeof(src->info.addr), &adr);
-								src->info.port = NET_AdrToPort(&adr);
+								//use the module's srflx_port override if set (e.g. game port
+								//behind Docker/symmetric NAT where STUN reflects an ephemeral port)
+								src->info.port = con->module->srflx_port ? con->module->srflx_port : NET_AdrToPort(&adr);
 								//if (net_from.connum >= 1 && net_from.connum < 1+MAX_NETWORKS && col->conn[net_from.connum-1])
 								//	col->conn[net_from.connum-1]->GetLocalAddresses(col->conn[net_from.connum-1], &relflags, &reladdr, &relpath, 1);
 								//FIXME: we don't really know which one... NET_BaseAdrToString(src->info.reladdr, sizeof(src->info.reladdr), &reladdr);

--- a/Quake/ice/ice_private.h
+++ b/Quake/ice/ice_private.h
@@ -262,6 +262,7 @@ struct icemodule_s
 	struct icesocket_s *conn[MAX_NETWORKS];
 	int setupudpport;	// for lazy retry if sockets fail at init
 	int setuptcpport;
+	int srflx_port;		// if set, override srflx candidate port (for NAT port mapping)
 
 	//private ICE state.
 	struct icemodule_s *next;
@@ -366,6 +367,7 @@ struct icesocket_s
 };
 struct icesocket_s *ICE_OpenUDP(netadrtype_t type, int port);
 struct icesocket_s *ICE_WrapExistingSocket(SOCKET sock, int af);
+struct icesocket_s *ICE_WrapExistingSocketSendOnly(SOCKET sock, int af);
 void ICE_SetupModule(struct icemodule_s *module, int udpport, int tcpport);
 
 enum addressscope_e NET_ClassifyAddress(const netadr_t *adr, const char **outdesc);

--- a/Quake/ice/ice_quake.c
+++ b/Quake/ice/ice_quake.c
@@ -823,12 +823,15 @@ static qice_connection_t *QICE_Setup(const char *address, qboolean isserver)
 			if (wrap)
 				newcon->icemodule.conn[1] = wrap;
 		}
+		newcon->icemodule.srflx_port = net_hostport;	// use game port for srflx candidates (NAT may remap)
 		ICE_SetupModule(&newcon->icemodule,
 			0,						// shared sockets handle UDP; 0 = don't open another
 			net_hostport);			// TCP/WebSocket on game port
 	}
 	else
 	{
+		if (isserver)
+			newcon->icemodule.srflx_port = net_hostport;	// use game port for srflx candidates (NAT may remap)
 		ICE_SetupModule(&newcon->icemodule,
 			0,						// ephemeral if needed (client), or none (no shared socket)
 			isserver ? net_hostport : 0);		// TCP/WebSocket on game port
@@ -899,7 +902,7 @@ static qice_connection_t *qice_hostcon;	//broker for our server side.
 //Decrypted packets are processed as connectionless with dtls_authenticated=true.
 #ifdef HAVE_DTLS
 #define MAX_BROKER_DTLS_PEERS 8
-#define BROKER_DTLS_TIMEOUT 60.0
+#define BROKER_DTLS_TIMEOUT 5.0
 struct broker_dtls_peer_s
 {
 	netadr_t addr;
@@ -1024,11 +1027,38 @@ qboolean BrokerDTLS_HandlePacket(byte *data, int len, struct qsockaddr *qaddr, s
 		return false;
 
 	{	struct broker_dtls_peer_s temp;
+		qboolean result;
 		memset(&temp, 0, sizeof(temp));
 		temp.addr = from;
 		temp.funcs = funcs;
 		temp.sendsock = sendsock;
-		return funcs->CheckConnection(&temp, &from, sizeof(from), data, len, BrokerDTLS_Push, BrokerDTLS_Established);
+		result = funcs->CheckConnection(&temp, &from, sizeof(from), data, len, BrokerDTLS_Push, BrokerDTLS_Established);
+
+		if (!result && len > 0 && data[0] == 0x17)
+		{	//application data with no session — broker has a stale DTLS session.
+			//send a DTLS fatal alert (unexpected_message) to force re-handshake.
+			static double last_alert_time;
+			double now = Sys_DoubleTime();
+			if (now - last_alert_time > 1.0)	//rate limit
+			{
+				byte alert[] = {
+					0x15,			//content type: alert
+					0xFE, 0xFD,		//DTLS 1.2 version
+					0x00, 0x00,		//epoch
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00,	//sequence number
+					0x00, 0x02,		//length
+					0x02,			//fatal
+					0x0A			//unexpected_message
+				};
+				if (sendsock)
+					sendsock->SendPacket(sendsock, &from, alert, sizeof(alert));
+				Con_DPrintf("BrokerDTLS: sent alert to %s (stale session)\n",
+					NET_BaseAdrToString((char[64]){0}, 64, &from));
+				last_alert_time = now;
+			}
+		}
+
+		return result;
 	}
 }
 
@@ -1164,16 +1194,46 @@ void SVC_ICE_Offer(const char *clientaddr, const char *brokerid, const char *sdp
 		return;
 	ice_peer_state[pi].timeout = Sys_DoubleTime() + 30;
 
+	//close any stale ICE state for this broker_id (e.g. from a previous offer/retry)
+	ice = iceapi.Find(&qice_hostcon->icemodule, brokerid);
+	if (ice)
+		iceapi.Close(ice, true);
+
 	ice = iceapi.Create(&qice_hostcon->icemodule, brokerid, clientaddr, ICEF_DEFAULT, ICEP_SERVER);
 	if (!ice)
 	{
 		Con_Printf("ICE: iceapi.Create failed for broker_id=%s\n", brokerid);
 		return;
 	}
+	iceapi.Set(ice, "brokerless", "1");	//not managed by WebSocket broker — clean up on failure/timeout
 
-	//use the broker as a STUN server to discover our server-reflexive address
+	//use the broker as a STUN server to discover our server-reflexive address.
+	//Use the broker's known IP (from the DTLS source) with the main broker port
+	//(from net_ice_broker cvar). The DTLS session may arrive from an ephemeral alt
+	//socket, so we can't use its source port directly. And we can't resolve the
+	//broker hostname — inside Docker it may resolve to an unreachable address.
 	if (brokeraddr && *brokeraddr)
-		iceapi.Set(ice, "server", va("stun:%s", brokeraddr));
+	{
+		char stunaddr[128];
+		const char *brokerhost = net_ice_broker.string;
+		int brokerport = PORT_ICEBROKER;
+		char *colon;
+
+		//extract just the port from the broker cvar
+		if (!strncmp(brokerhost, "ws://", 5)) brokerhost += 5;
+		else if (!strncmp(brokerhost, "wss://", 6)) brokerhost += 6;
+		colon = strrchr(brokerhost, ':');
+		if (colon)
+			brokerport = atoi(colon + 1);
+
+		//extract just the IP from brokeraddr (strip its port)
+		q_strlcpy(stunaddr, brokeraddr, sizeof(stunaddr));
+		colon = strrchr(stunaddr, ':');
+		if (colon)
+			*colon = 0;
+
+		iceapi.Set(ice, "server", va("stun:%s:%d", stunaddr, brokerport));
+	}
 
 	s = net_ice_servers.string;
 	while((s=COM_Parse(s)))
@@ -2242,6 +2302,17 @@ void NQICE_ShareGameSocket (sys_socket_t sock)
 	wrap = ICE_WrapExistingSocket(sock, af);
 	if (wrap)
 		*slot = wrap;
+
+	//put a send-only wrapper in the host module so ICE responses (STUN binding
+	//replies, connectivity checks) go out through the game port, not an ephemeral port.
+	//send-only so ICE_ProcessModule won't steal packets from the datagram driver.
+	if (wrap && qice_hostcon)
+	{
+		int idx = (af == AF_INET6) ? 1 : 0;
+		if (qice_hostcon->icemodule.conn[idx])
+			qice_hostcon->icemodule.conn[idx]->CloseSocket(qice_hostcon->icemodule.conn[idx]);
+		qice_hostcon->icemodule.conn[idx] = ICE_WrapExistingSocketSendOnly(sock, af);
+	}
 }
 
 qboolean NQICE_ProcessPacket (byte *data, int len, struct qsockaddr *addr, void(*callback)(qsocket_t *))

--- a/Quake/ice/ice_socket.c
+++ b/Quake/ice/ice_socket.c
@@ -787,6 +787,10 @@ static void ICEUDP_NoClose(struct icesocket_s *s)
 {	//do NOT close the socket — we don't own it
 	free(s);
 }
+static int ICEUDP_NoRecv(struct icesocket_s *s, netadr_t *addr, void *data, size_t datasize)
+{	//send-only wrapper — datagram driver handles recv, we just need to send through this socket
+	return 0;
+}
 struct icesocket_s *ICE_WrapExistingSocket(SOCKET sock, int af)
 {	//wrap an existing socket for ICE use without taking ownership
 	struct icesocket_s *n = calloc(1, sizeof(*n));
@@ -796,6 +800,21 @@ struct icesocket_s *ICE_WrapExistingSocket(SOCKET sock, int af)
 	n->RecvPacket = ICEUDP_RecvPacket;
 	n->EnumerateAddresses = ICEUDP_GetAddresses;
 	n->CloseSocket = ICEUDP_NoClose;	//don't close — datagram driver owns it
+	n->af = af;
+	n->sock = sock;
+	return n;
+}
+struct icesocket_s *ICE_WrapExistingSocketSendOnly(SOCKET sock, int af)
+{	//send-only wrapper — can send through the socket but recv always returns 0.
+	//used to put the shared game socket in a module's conn[] for sending responses
+	//without ICE_ProcessModule stealing packets from the datagram driver.
+	struct icesocket_s *n = calloc(1, sizeof(*n));
+	if (!n)
+		return NULL;
+	n->SendPacket = ICEUDP_SendPacket;
+	n->RecvPacket = ICEUDP_NoRecv;
+	n->EnumerateAddresses = ICEUDP_GetAddresses;
+	n->CloseSocket = ICEUDP_NoClose;
 	n->af = af;
 	n->sock = sock;
 	return n;

--- a/Quake/ice/ice_stream.c
+++ b/Quake/ice/ice_stream.c
@@ -835,6 +835,20 @@ static int WS_ReadBytes (struct icestream_s *file, void *buffer, int bytestoread
 					{
 						f->serverwaiting = false;
 						f->pendingofs = 0;
+
+						//handle health check pings — respond with HTTP 200, don't upgrade
+						if (!strncmp(f->readbuffer, "GET /;/ping ", 12))
+						{
+							f->pendingsize = q_snprintf(f->pending, f->pendingmax,
+								"HTTP/1.1 200 OK\r\n"
+								"Content-Length: 0\r\n"
+								"Connection: close\r\n"
+								"\r\n");
+							WS_Flush(f);
+							f->err = VFS_ERROR_UNSPECIFIED;	//close after flush
+							break;
+						}
+
 						if (f->err)
 						{
 #if 1
@@ -898,6 +912,18 @@ static int WS_ReadBytes (struct icestream_s *file, void *buffer, int bytestoread
 								//so we no longer need the old hack (fake CCREQ + frame translation).
 								//just accept 'quake' subprotocol and pass raw packets through.
 #endif
+						}
+
+						//log the request line and subprotocol for debugging
+						{
+							char reqline[128];
+							const char *rl = f->readbuffer;
+							const char *rle = rl;
+							while (*rle && *rle != '\r' && *rle != '\n' && (rle - rl) < (int)sizeof(reqline)-1)
+								rle++;
+							memcpy(reqline, rl, rle - rl);
+							reqline[rle - rl] = 0;
+							Con_DPrintf("WebSocket accepted: %s (proto: %s)\n", reqline, prot ? prot : f->protocol);
 						}
 
 						WS_Flush(f);	//flush any pending writes, so the client knows it can start sending everything else.

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -1030,7 +1030,7 @@ void Datagram_GetAnyMessages(void(*callback)(qsocket_t *))
 				}
 			}
 			if (!s)
-			{	//unmatched packet — try broker DTLS, then ICE (STUN/DTLS/SCTP)
+			{	//unmatched packet — try ICE (STUN/DTLS/SCTP)
 				byte leadbyte = ((byte *)&packetBuffer)[0];
 				if (leadbyte < 4 || (leadbyte >= 20 && leadbyte < 64))
 					NQICE_ProcessPacket((byte *)&packetBuffer, length, &addr, callback);

--- a/Quake/net_wins.c
+++ b/Quake/net_wins.c
@@ -378,10 +378,8 @@ int WINS_Read (sys_socket_t socketid, byte *buf, int len, struct qsockaddr *addr
 	if (ret == SOCKET_ERROR)
 	{
 		int err = SOCKETERRNO;
-		if (err == NET_EWOULDBLOCK || err == NET_ECONNREFUSED)
+		if (err == NET_EWOULDBLOCK || err == NET_ECONNREFUSED || err == WSAECONNRESET)
 			return 0;
-		if (err == WSAECONNRESET)
-			Con_DPrintf ("WINS_Read, recvfrom: %s (%s)\n", socketerror(err), WINS_AddrToString(addr, false));
 		else
 			Con_SafePrintf ("WINS_Read, recvfrom: %s\n", socketerror(err));
 	}

--- a/Quake/sys_sdl_win.c
+++ b/Quake/sys_sdl_win.c
@@ -406,8 +406,6 @@ void Sys_Init (void)
 			use_vtp = SetConsoleMode (houtput, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 			SetConsoleOutputCP (CP_UTF8);
 			GetConsoleMode (hinput, &mode);
-			mode |= ENABLE_MOUSE_INPUT;
-			mode &= ~ENABLE_QUICK_EDIT_MODE;
 			SetConsoleMode (hinput, mode | ENABLE_EXTENDED_FLAGS);
 		}
 	}
@@ -537,7 +535,7 @@ static int Scrollback_TermWidth (void)
 static char	ded_input[MAXCMDLINE];
 static int	ded_input_len;
 static int	ded_input_cursor;
-cvar_t		sys_dedmouse_capture = {"sys_dedmouse_capture", "1", CVAR_ARCHIVE};
+cvar_t		sys_dedmouse_capture = {"sys_dedmouse_capture", "0", CVAR_ARCHIVE};
 
 static qboolean Scrollback_ShowCaretRow (void)
 {
@@ -1183,6 +1181,29 @@ const char *Sys_ConsoleInput (void) // woods #arrowkeys #serverhistory
 	INPUT_RECORD	recs[1024];
 	int		ch;
 	DWORD		dummy, numread, numevents;
+
+	//apply mouse capture / quick edit mode dynamically based on cvar
+	{
+		static int last_mouse_capture = -1;
+		int want = (int)sys_dedmouse_capture.value;
+		if (want != last_mouse_capture)
+		{
+			DWORD mode = 0;
+			GetConsoleMode(hinput, &mode);
+			if (want)
+			{
+				mode |= ENABLE_MOUSE_INPUT;
+				mode &= ~ENABLE_QUICK_EDIT_MODE;
+			}
+			else
+			{
+				mode &= ~ENABLE_MOUSE_INPUT;
+				mode |= ENABLE_QUICK_EDIT_MODE;
+			}
+			SetConsoleMode(hinput, mode | ENABLE_EXTENDED_FLAGS);
+			last_mouse_capture = want;
+		}
+	}
 
 	for ( ;; )
 	{


### PR DESCRIPTION
 ### Fixes multiple issues with the UDP/DTLS relay path for browser-to-server connections running behind Docker NAT.                                                          
  DTLS Session Lifecycle (ice_quake.c)                                                                                                                                  
  
  - Reduced BROKER_DTLS_TIMEOUT from 60s to 5s — matches the broker's own session timeout so stale server-side sessions expire before the broker's next connection
  attempt.
  - Stale session alert — when the server receives DTLS application data (0x17) with no existing session (broker has a stale session), it sends a DTLS fatal
  unexpected_message alert to force the broker to re-handshake. Rate-limited to once per second.
  - Stale ICE state cleanup — SVC_ICE_Offer now calls iceapi.Find + iceapi.Close to destroy any existing ICE state for the same broker_id before creating a new one.    
  Prevents iceapi.Create from failing on duplicate IDs when the broker retries.
  - Brokerless ICE states — ICE states created by SVC_ICE_Offer are now marked brokerless via a new iceapi.Set(ice, "brokerless", "1") property, so they get cleaned up 
  automatically on timeout/failure.

  Brokerless State Destruction (ice_main.c)

  - ICE_Tick — brokerless states in ICE_FAILED are now destroyed immediately (previously only ICE_GATHERING and below were destroyed, leaving failed states to log      
  timeouts forever).
  - brokerless property — added "brokerless" to ICE_Set so it can be set from ice_quake.c without accessing the struct directly.

  STUN Address Fix (ice_quake.c)

  - Correct STUN server address — uses the broker's known IP (from the DTLS source address) combined with the main broker port (from net_ice_broker cvar). Previously   
  used the DTLS source port directly, which was the broker's ephemeral alt socket — not the port where STUN is served. DNS resolution of the broker hostname is avoided 
  since it may fail or resolve to an unreachable address inside Docker.

  NAT Port Override (ice_main.c, ice_private.h, ice_quake.c)

  - srflx_port field on icemodule_s — when set, overrides the port on server-reflexive candidates. Behind Docker bridge NAT, STUN reflects an ephemeral port that isn't 
  forwarded — only the game port is reachable.
  - Set to net_hostport for servers in both the shared-socket and ephemeral-socket paths in QICE_Setup.

  Send-Only Socket Wrapper (ice_socket.c, ice_quake.c)

  - ICE_WrapExistingSocketSendOnly — new wrapper that can send through the game socket but returns 0 from RecvPacket. Prevents ICE_ProcessModule from stealing packets  
  off the shared game socket (the datagram driver handles recv), while allowing ICE to send STUN responses and connectivity check replies from the correct port.        
  - NQICE_ShareGameSocket — now also installs a send-only wrapper in qice_hostcon->icemodule.conn[], replacing any ephemeral socket that was opened during init.        

  Windows Fixes

  - WSAECONNRESET handled as non-fatal (net_wins.c) — on Windows, sending a UDP packet that triggers ICMP port unreachable causes the next recvfrom to fail with        
  WSAECONNRESET. Now treated the same as ECONNREFUSED (return 0, try again next frame) instead of returning -1 which broke the recv loop.
  - Dedicated console Quick Edit (sys_sdl_win.c) — ENABLE_QUICK_EDIT_MODE is no longer disabled at startup. sys_dedmouse_capture cvar defaults to 0 (text selection     
  works). Console mode is applied dynamically when the cvar changes.

  ---
  Commit 5d4e6ae7 — Handle connection-less ping requests

  Reduces log noise from broker health check pings and WebSocket connection churn.

  WebSocket Ping Handler (ice_stream.c)

  - HTTP 200 response for /;/ping — when the broker's ws library sends a health check ping via GET /;/ping, the server now responds with HTTP 200 and closes the        
  connection instead of upgrading to WebSocket. Prevents creation of ICE states that would timeout and spam the console.

  Log Noise Reduction (ice_main.c)

  - WebSocket connection and Direct connection messages downgraded from Con_Printf to Con_DPrintf — only visible with developer 1+. These fire on every inbound TCP     
  connection (including health checks) and were flooding the console.
  - Brokerless ICE timeout — no longer routed through ICE_SetFailed (which uses Con_Printf). Instead sets ICE_FAILED directly with a Con_DPrintf message, then destroyed
   on the next tick.